### PR TITLE
docs: CONTEXT and ADR-0001 foundations for content authoring skills

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,48 @@
+# Ocobo Content Repository
+
+This repo holds the markdown content consumed by the Ocobo website. It replaces a traditional CMS — Ocobo teams edit content here via Claude Code and ship it through GitHub PRs.
+
+## Language
+
+**Content**:
+The umbrella term for everything published by the website that lives in this repo: blog posts, stories, team members, tools, jobs.
+_Avoid_: posts (overloaded — see "Flagged ambiguities").
+
+**Blog post**:
+A long-form article in `blog/<lang>/`, typically authored by a team member, often tied to the Revenue Echoes podcast.
+_Avoid_: article, post (alone).
+
+**Story**:
+A customer case study in `stories/<lang>/`, describing a mission Ocobo delivered for a named client.
+_Avoid_: case study, success story (acceptable colloquially, but `story` is the canonical filename and frontmatter convention).
+
+**Team member**:
+A person on the Ocobo team, represented by a single file in `team/`. Slug = identity; referenced by blog posts (`author`) and jobs (`hiringContact`).
+_Avoid_: member (alone), author (that's a role, not the entity).
+
+**Tool**:
+A third-party software product Ocobo deploys or recommends to clients (e.g. HubSpot, Salesforce). Represented by a single file in `tools/`. Slug = identity; referenced by stories (`tools`, `featuredTool`).
+_Avoid_: software, vendor, product.
+
+**Job**:
+An open position in `jobs/<lang>/`. References a `hiringContact` (team member slug).
+_Avoid_: role (overloaded — see "Flagged ambiguities"), offer, posting.
+
+**Slug**:
+The kebab-case filename (without `.md`) that uniquely identifies a piece of content within its type. Cross-references between content types use slugs.
+
+**Frontmatter**:
+The YAML block at the top of each markdown file, between `---` fences. Defines structured fields; the markdown body below is the long-form content.
+
+## Relationships
+
+- A **Blog post** has exactly one author, which is a **Team member** slug.
+- A **Story** references zero-or-more **Tools** by slug, and designates one as `featuredTool` (which must be in the `tools` list).
+- A **Job** has exactly one `hiringContact`, which is a **Team member** slug.
+- A **Team member** can be referenced by many **Blog posts** and **Jobs**.
+- A **Tool** can be referenced by many **Stories**.
+
+## Flagged ambiguities
+
+- **"post"** was used both as the repo name (`ocobo-posts` = all content) and as a synonym for "blog post" (e.g. `assets/posts/`). Resolved: use **Content** as the umbrella term and **Blog post** for articles. The repo name and `assets/posts/` directory are kept as-is for backward compatibility.
+- **"role"** appears as both a Team member field (job title, e.g. "Partner") and a Story field (the speaker's role at the client). Resolved: both usages are job titles, just for different people — no rename needed, context disambiguates.

--- a/docs/adr/0001-notion-as-content-staging.md
+++ b/docs/adr/0001-notion-as-content-staging.md
@@ -1,0 +1,12 @@
+# Notion as content staging area, GitHub as published source of truth
+
+Authors and reviewers draft content (blog posts, stories, team members, tools, jobs) in Notion databases — one DB per content type, with properties mapped to the markdown frontmatter. A Claude Code skill imports each Notion page into the repo (frontmatter + body + assets), opens a PR, and from that point the markdown file in `main` is read-only relative to Notion: corrections happen in GitHub, not in Notion.
+
+We picked this over "edit markdown directly in GitHub" because the dominant authors are non-tech Ocobo team members who already work in Notion and use NotionAI; asking them to write YAML+markdown in a terminal would block adoption. We picked the unidirectional sync (Notion → GitHub, then GitHub is canonical) over bidirectional sync because two-way sync against Notion is brittle and would require infrastructure beyond a Claude Code skill.
+
+## Consequences
+
+- Each user needs an MCP Notion connection authenticated against the Ocobo workspace (setup doc: `docs/mcp-notion-setup.md`).
+- Notion DB schemas must stay aligned with the Zod schemas in `scripts/schemas/`. Drift is detected at import time (validation fails).
+- Notion pages become stale after import — they are not the source of truth for what's live on the website.
+- An interview fallback in each skill covers cases where Notion is impractical (urgent fix, very short content).


### PR DESCRIPTION
## Summary

Foundations for the content authoring skills chantier (#21):

- **`CONTEXT.md`** — domain glossary establishing the canonical vocabulary (5 content types: blog post, story, team member, tool, job; cross-references via slug; flagged ambiguities like "post").
- **`docs/adr/0001-notion-as-content-staging.md`** — unidirectional sync decision: Notion is the staging area for drafts; once a page is imported via a Claude Code skill, GitHub becomes the source of truth and corrections happen on the markdown.

No code changes. These docs underpin the 8 implementation slices tracked in #22–#29.

## Test plan

- [ ] `CONTEXT.md` reads cleanly and the glossary matches how the team talks about the content.
- [ ] `docs/adr/0001-notion-as-content-staging.md` accurately captures the trade-off (Notion editing UX vs. GitHub as source of truth).
- [ ] No regression on existing content (no `.md` files in `blog/`, `stories/`, `team/`, `tools/`, `jobs/` were touched).