### PR TITLE
chore(agents): set up Pocock skills config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# Ocobo Content Repository — agent instructions
+
+This repo holds the markdown content consumed by the Ocobo website. Read `CONTEXT.md` for the domain glossary and `docs/adr/` for past architectural decisions before doing non-trivial work.
+
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs live as GitHub issues in `ocobo-revops/posts`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default Pocock label vocabulary, one-to-one with canonical roles. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context. `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,40 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+This repo is **single-context**.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root — domain glossary (Content, Blog post, Story, Team member, Tool, Job, Slug, Frontmatter) and relationships between content types.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront.
+
+## File structure
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   └── 0001-notion-as-content-staging.md
+└── (assets, blog, jobs, legal, stories, team, tools)
+```
+
+## Use the glossary's vocabulary
+
+When output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids — notably:
+
+- "Content" (umbrella), not "posts" (which refers specifically to the repo dir `assets/posts/` kept for backward compat)
+- "Blog post" for articles, not "article" or "post" alone
+- "Story" for case studies, not "case study" or "success story"
+- "Team member" for people, not "member" or "author" alone
+- "Tool" for third-party software, not "vendor" or "product"
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap.
+
+## Flag ADR conflicts
+
+If output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0001 (Notion as content staging) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues in `ocobo-revops/posts`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue in `ocobo-revops/posts`.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Canonical role     | Label in `ocobo-revops/posts` | Meaning                                  |
+| ------------------ | ----------------------------- | ---------------------------------------- |
+| `needs-triage`     | `needs-triage`                | Maintainer needs to evaluate this issue  |
+| `needs-info`       | `needs-info`                  | Waiting on reporter for more information |
+| `ready-for-agent`  | `ready-for-agent`             | Fully specified, ready for an AFK agent  |
+| `ready-for-human`  | `ready-for-human`             | Requires human implementation            |
+| `wontfix`          | `wontfix`                     | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Create any missing labels with `gh label create <name> --description "..." --color <hex>` before applying.


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` with an `## Agent skills` block at the repo root.
- Add `docs/agents/{issue-tracker,triage-labels,domain}.md` so engineering skills (`to-prd`, `to-issues`, `triage`, `tdd`, `improve-codebase-architecture`, …) know:
  - Issues live in GitHub (`ocobo-revops/posts`), use `gh` CLI.
  - Triage labels match the canonical Pocock vocabulary one-to-one.
  - Domain doc layout is single-context, anchored on `CONTEXT.md` + `docs/adr/`.

Prereq for the DX milestone (#3 — DX & guardrails — asset pipeline) whose PRD is tracked in #38.

## Test plan

- [x] Files render correctly on GitHub.
- [x] Skill `to-prd` was used to produce #38 against this config — no missing-context warnings.