### PR TITLE
[Slice 4] new-content skill — Notion adapter

### DIFF
--- a/.claude/skills/new-content/SKILL.md
+++ b/.claude/skills/new-content/SKILL.md
@@ -10,29 +10,75 @@ When a user wants to create a new blog post, story, team member profile, tool en
 
 `--type <type>` — skip the type prompt. Valid: `blog-post | story | team-member | tool | job`.
 
-`[path]` — optional positional arg. Any non-flag argument is treated as a source file path. The file is parsed before the interview — recognised fields pre-fill the answers, prose becomes the body. Examples:
+`[source]` — optional positional arg. Can be:
+- A **Notion URL** — `https://notion.so/...` or `https://www.notion.so/...` — triggers the Notion adapter.
+- A **local file path** — any other non-flag argument — triggers the local-file adapter.
 
+Pre-filled fields from either adapter reduce the interview to only what's missing.
+
+Examples:
+
+    new-content https://notion.so/Mon-article-abc123
+    new-content --type blog-post https://notion.so/abc123
     new-content path/to/draft.md
     new-content --type blog-post path/to/draft.md
 
 ---
 
-## Step 0 — Parse source file
+## Step 0 — Parse source
 
-_Skip this step if no file path arg was provided._
+_Skip this step if no source arg was provided._
 
-Run the local-file adapter:
+**Detect source type** — check if the arg matches `^https?://(www\.)?notion\.(so|site)/`:
+- Yes → **Notion path** (Step 0A)
+- No → **Local file path** (Step 0B)
+
+Store the result (from whichever path) as `prefilled`:
+- `prefilled.fields` — extracted key-value pairs (may be empty)
+- `prefilled.body` — extracted prose (may be empty)
+- `prefilled.assets` — image URLs to download (Notion only; empty for local files)
+
+If any step below exits non-zero, stop and show the error — do not proceed to Step 1.
+
+---
+
+### Step 0A — Notion adapter
+
+1. **Check MCP availability** — verify the Notion MCP is connected by attempting a simple call. If not available:
+   > Notion MCP is not configured. To use Notion import, follow `docs/mcp-notion-setup.md`. Falling back — use interview mode or pass a local file path instead.
+   Then proceed to Step 1 with empty `prefilled`.
+
+2. **Fetch the page** — use the `notion-fetch` MCP tool with the URL. This returns the page properties and content.
+
+3. **Determine type** — if `--type` was passed, use it. Otherwise check `prefilled.fields` for a recognisable type hint, or fall back to Step 1 prompt after extracting fields.
+
+4. **Map properties** — save the page JSON from `notion-fetch` to a temp file, then run:
+   ```bash
+   node scripts/source-adapters/notion.js /tmp/notion-page.json <type> [/tmp/notion-body.txt]
+   ```
+   The adapter outputs `{"fields": {...}, "body": "...", "assets": [...]}`.
+
+5. **Download images** — for each entry in `assets[]`, download the URL to the correct local path before Step 6:
+   ```bash
+   curl -L "<url>" -o "<target-path>"
+   ```
+   Target paths follow the same convention as Step 6 (slug-based). Record each downloaded path.
+
+   > **Note:** Notion file URLs (type `file`) are temporary S3 URLs that expire in ~1 hour — download immediately.
+
+---
+
+### Step 0B — Local file adapter
+
+Run:
 
 ```bash
 node scripts/source-adapters/local-file.js "<path>"
 ```
 
-The adapter outputs `{"fields": {...}, "body": "..."}` to stdout. Store this as `prefilled`.
+The adapter outputs `{"fields": {...}, "body": "..."}` to stdout. `assets` is always `[]` for local files.
 
-- `prefilled.fields` — key-value pairs extracted from the file (frontmatter > key-value lines > empty for prose)
-- `prefilled.body` — remaining prose content (empty when the file had only frontmatter)
-
-If the command exits with a non-zero code (file not found, unreadable), stop and show the error to the user — do not proceed to Step 1.
+If the command exits non-zero (file not found, unreadable), stop and show the error.
 
 ---
 

--- a/docs/mcp-notion-setup.md
+++ b/docs/mcp-notion-setup.md
@@ -1,0 +1,33 @@
+# Notion MCP setup
+
+Connects the Notion MCP to Claude Code so `new-content` can import pages directly from the Ocobo Notion workspace.
+
+## Prerequisites
+
+- Access to the Ocobo Notion workspace
+- Claude.ai account (claude.ai/code or desktop app)
+
+## Setup steps
+
+1. **Open Claude.ai → Settings → Integrations**
+
+2. **Add Notion** — click "Add integration" and select Notion.
+
+3. **Authorise the Ocobo workspace** — when Notion asks which workspace to connect, select the Ocobo workspace. Grant the requested permissions (read pages and databases).
+
+4. **Verify the connection** — in Claude Code, run:
+   ```
+   new-content https://notion.so/<any-page-url>
+   ```
+   If the MCP is connected, Claude will fetch the page and begin mapping fields. If it is not connected, you will see:
+   > Notion MCP is not configured. To use Notion import, follow `docs/mcp-notion-setup.md`.
+
+## Troubleshooting
+
+**"Notion MCP is not configured"** — the integration was not found. Re-check Settings → Integrations and confirm the Notion tile shows "Connected".
+
+**"Cannot access this page"** — the page is in a workspace or space that was not included in the authorisation. Share the page with the Ocobo integration or re-authorise with broader workspace access.
+
+**Image URLs expire** — Notion file attachments use temporary S3 URLs (valid ~1 hour). The skill downloads images immediately on import. If you get a 403 on an image, re-run the import from the original Notion URL.
+
+**Works without Notion MCP** — all other `new-content` modes (interview, local file) work without any MCP setup.

--- a/docs/notion-templates/README.md
+++ b/docs/notion-templates/README.md
@@ -1,0 +1,47 @@
+# Notion templates — overview
+
+Templates for staging Ocobo content in Notion before importing via `new-content`.
+
+## Flow
+
+```
+Author drafts page in Notion database
+        ↓
+new-content https://notion.so/<page-url>
+        ↓
+Notion MCP fetches page properties + content
+        ↓
+notion.js maps properties → frontmatter fields
+        ↓
+Claude interviews for any missing required fields
+        ↓
+pnpm validate → publish-content → PR
+```
+
+## Property naming conventions
+
+Each Notion database should use the exact property names listed in the per-type template files. The adapter also accepts common French and English variants — see each file for the full alias list.
+
+The Notion page **title** (the primary `Title` property) always maps to the main identifier of the content:
+- Blog post → `title` (article title)
+- Story → `name` (client company name)
+- Team member → `name` (full name)
+- Tool → `name` (display name)
+- Job → `title` (job title)
+
+## Per-type templates
+
+| Type | File |
+|------|------|
+| Blog post | [blog-post.md](blog-post.md) |
+| Story | [story.md](story.md) |
+| Team member | [team-member.md](team-member.md) |
+| Tool | [tool.md](tool.md) |
+| Job | [job.md](job.md) |
+
+## Setup
+
+1. Follow `docs/mcp-notion-setup.md` to connect the Notion MCP.
+2. Create a Notion database for the content type you need.
+3. Add the properties listed in the relevant template file.
+4. Use the NotionAI prompt in the template to scaffold the database automatically.

--- a/docs/notion-templates/blog-post.md
+++ b/docs/notion-templates/blog-post.md
@@ -1,0 +1,60 @@
+# Blog post — Notion template
+
+## Property mapping
+
+| Notion property | Notion type | Frontmatter field | Required |
+|----------------|-------------|-------------------|----------|
+| Title | Title | `title` | ✅ |
+| Author | Select | `author` | ✅ |
+| Description | Text | `description` | ✅ |
+| Date | Date | `date` | ✅ |
+| Image | Files & media | `image` | ✅ |
+| Lang | Select | `lang` | recommended |
+| Tags | Multi-select | `tags` | optional |
+| Read | Text | `read` | optional |
+| Exerpt | Text | `exerpt` | optional |
+| Podcast ID | Text | `podcastId` | optional |
+
+**Accepted aliases** (adapter tries these in order if exact name is not found):
+- Title → `Titre`, `Name`
+- Author → `Auteur`
+- Image → `Cover`, `Couverture`
+- Lang → `Language`, `Langue`
+- Read → `Reading time`, `Temps de lecture`
+- Exerpt → `Excerpt`, `Résumé`
+- Podcast ID → `PodcastId`, `Podcast`
+
+**Author** values must match an active team member slug (e.g. `jerome-boileux`). The skill validates this during the interview.
+
+**Image** — upload the cover image directly as a Notion file attachment, or link an external URL. The adapter takes the first file.
+
+**Page body** — write the article body in the Notion page itself (below properties). The `notion-fetch` MCP call returns this as markdown.
+
+## NotionAI scaffold prompt
+
+Use this prompt in a new Notion page with NotionAI (/ → AI) to create the database:
+
+> Create a database called "Blog posts" with these properties:
+> - Title (title)
+> - Author (select) — options: [add your team slugs]
+> - Description (text)
+> - Date (date)
+> - Image (files & media)
+> - Lang (select) — options: fr, en
+> - Tags (multi-select)
+> - Read (text)
+> - Exerpt (text)
+> - Podcast ID (text)
+
+## Sample page
+
+| Property | Value |
+|----------|-------|
+| Title | Comment Yousign a transformé sa RevOps |
+| Author | jerome-boileux |
+| Description | Un retour d'expérience sur la structuration RevOps de Yousign. |
+| Date | 2024-03-15 |
+| Image | [cover.jpg] |
+| Lang | fr |
+| Tags | strategy, ops |
+| Read | 6 min |

--- a/docs/notion-templates/job.md
+++ b/docs/notion-templates/job.md
@@ -1,0 +1,80 @@
+# Job — Notion template
+
+## Property mapping
+
+| Notion property | Notion type | Frontmatter field | Required |
+|----------------|-------------|-------------------|----------|
+| Title | Title | `title` | ✅ |
+| Contract type | Select | `contractType` | ✅ |
+| Seniority | Text | `seniority` | ✅ |
+| Location | Text | `location` | ✅ |
+| Start date | Date | `startDate` | ✅ |
+| Hiring contact | Select | `hiringContact` | ✅ |
+| Tally form ID | Text | `tallyFormId` | ✅ |
+| Status | Select | `status` | ✅ |
+| Published at | Date | `publishedAt` | ✅ |
+| Lang | Select | `lang` | recommended |
+| Icon | Text | `icon` | optional (emoji) |
+| Apply email | Email | `applyEmail` | optional |
+| Intro | Text | `intro` | optional |
+
+**Accepted aliases:**
+- Title → `Titre`, `Name`
+- Contract type → `Type de contrat`
+- Seniority → `Séniorité`
+- Location → `Lieu`
+- Start date → `Date de début`
+- Hiring contact → `Contact RH`
+- Apply email → `Email candidature`
+- Tally form ID → `TallyFormId`
+- Status → `Statut`
+- Published at → `Date de publication`
+- Lang → `Language`, `Langue`
+- Icon → `Icône`
+
+**Status** — one of `published`, `draft`, `closed`.
+
+**Hiring contact** — must match an active team member slug.
+
+**Page body** — write the job description in three sections in the Notion page body:
+```
+### La Mission
+...
+### Responsabilités
+...
+### Profil recherché
+...
+```
+
+## NotionAI scaffold prompt
+
+> Create a database called "Jobs" with these properties:
+> - Title (title)
+> - Contract type (select) — options: CDI, CDD, Freelance, Stage
+> - Seniority (text)
+> - Location (text)
+> - Start date (date)
+> - Hiring contact (select) — add team member slugs as options
+> - Tally form ID (text)
+> - Status (select) — options: published, draft, closed
+> - Published at (date)
+> - Lang (select) — options: fr, en
+> - Icon (text) — a single emoji
+> - Apply email (email)
+> - Intro (text)
+
+## Sample page
+
+| Property | Value |
+|----------|-------|
+| Title | RevOps Manager |
+| Contract type | CDI |
+| Seniority | 3-5 ans |
+| Location | Paris (On site) |
+| Start date | 2024-09-01 |
+| Hiring contact | alice-dupont |
+| Tally form ID | mK0Q4g |
+| Status | published |
+| Published at | 2024-08-01 |
+| Lang | fr |
+| Icon | 🚀 |

--- a/docs/notion-templates/story.md
+++ b/docs/notion-templates/story.md
@@ -1,0 +1,71 @@
+# Story (case study) — Notion template
+
+## Property mapping
+
+| Notion property | Notion type | Frontmatter field | Required |
+|----------------|-------------|-------------------|----------|
+| Name | Title | `name` (client company) | ✅ |
+| Date | Date | `date` | ✅ |
+| Title | Text | `title` | ✅ |
+| Subtitle | Text | `subtitle` | ✅ |
+| Description | Text | `description` | ✅ |
+| Speaker | Text | `speaker` | ✅ |
+| Role | Text | `role` | ✅ |
+| Duration | Text | `duration` | ✅ |
+| Scopes | Multi-select | `scopes` | ✅ |
+| Tools | Multi-select | `tools` | ✅ |
+| Featured tool | Select | `featuredTool` | ✅ |
+| Lang | Select | `lang` | recommended |
+| Quotes | Text | `quotes` | optional |
+| Deliverables | Text | `deliverables` | optional |
+
+**Accepted aliases:**
+- Name → `Client`, `Nom`
+- Title → `Titre`
+- Subtitle → `Sous-titre`
+- Speaker → `Contact`, `Interlocuteur`
+- Role → `Rôle`, `Job title`
+- Duration → `Durée`
+- Scopes → `Périmètres`
+- Tools → `Outils`
+- Featured tool → `Outil principal`, `Featured Tool`
+- Lang → `Language`, `Langue`
+
+**Tools / Scopes** — values must match existing tool slugs and scope names in the repo. The skill shows existing values during the interview.
+
+**Featured tool** must be one of the values in Tools.
+
+**Page body** — write the mission description (markdown) in the Notion page body.
+
+## NotionAI scaffold prompt
+
+> Create a database called "Stories" with these properties:
+> - Name (title) — the client company name
+> - Date (date)
+> - Title (text) — the case study headline
+> - Subtitle (text)
+> - Description (text)
+> - Speaker (text)
+> - Role (text)
+> - Duration (text)
+> - Scopes (multi-select)
+> - Tools (multi-select)
+> - Featured tool (select)
+> - Lang (select) — options: fr, en
+> - Quotes (text)
+> - Deliverables (text)
+
+## Sample page
+
+| Property | Value |
+|----------|-------|
+| Name | Yousign |
+| Date | 2024-01-10 |
+| Title | De 0 à une équipe RevOps en 18 mois |
+| Subtitle | Startup SaaS spécialisée dans la signature électronique |
+| Speaker | Jean Dupont |
+| Role | Head of Revenue |
+| Duration | 6 mois |
+| Scopes | Acquisition, CRM |
+| Tools | hubspot, gsheet |
+| Featured tool | hubspot |

--- a/docs/notion-templates/story.md
+++ b/docs/notion-templates/story.md
@@ -15,7 +15,6 @@
 | Scopes | Multi-select | `scopes` | ✅ |
 | Tools | Multi-select | `tools` | ✅ |
 | Featured tool | Select | `featuredTool` | ✅ |
-| Lang | Select | `lang` | recommended |
 | Quotes | Text | `quotes` | optional |
 | Deliverables | Text | `deliverables` | optional |
 
@@ -29,7 +28,6 @@
 - Scopes → `Périmètres`
 - Tools → `Outils`
 - Featured tool → `Outil principal`, `Featured Tool`
-- Lang → `Language`, `Langue`
 
 **Tools / Scopes** — values must match existing tool slugs and scope names in the repo. The skill shows existing values during the interview.
 
@@ -51,7 +49,6 @@
 > - Scopes (multi-select)
 > - Tools (multi-select)
 > - Featured tool (select)
-> - Lang (select) — options: fr, en
 > - Quotes (text)
 > - Deliverables (text)
 

--- a/docs/notion-templates/team-member.md
+++ b/docs/notion-templates/team-member.md
@@ -1,0 +1,69 @@
+# Team member — Notion template
+
+## Property mapping
+
+| Notion property | Notion type | Frontmatter field | Required |
+|----------------|-------------|-------------------|----------|
+| Name | Title | `name` | ✅ |
+| Role FR | Text | `role.fr` | ✅ |
+| Role EN | Text | `role.en` | ✅ |
+| Track | Select | `track` | ✅ |
+| Avatar | Files & media | `avatar` | ✅ |
+| Bio FR | Text | `bio.fr` | ✅ |
+| Bio EN | Text | `bio.en` | ✅ |
+| LinkedIn | URL | `linkedin` | optional |
+| Display order | Number | `displayOrder` | optional |
+| Active | Checkbox | `active` | optional (default true) |
+| Featured on about us | Checkbox | `featuredOnAboutUs` | optional |
+| Color | Select | `color` | optional |
+
+**Accepted aliases:**
+- Name → `Nom`
+- Role FR → `Rôle FR`, `Role (FR)`
+- Role EN → `Role (EN)`
+- Avatar → `Photo`
+- Bio FR → `Bio (FR)`
+- Bio EN → `Bio (EN)`
+- LinkedIn → `Linkedin`
+- Display order → `Order`, `Ordre`
+- Featured on about us → `Featured`
+- Color → `Couleur`
+
+**Track** — existing values: `architect`, `builder`, `expert-engineer`. Warn on new values during interview.
+
+**Avatar** — upload the team member's photo as a Notion file attachment. The adapter downloads it to `assets/team/<slug>.<ext>` during import.
+
+**Color** — one of `yellow`, `coral`, `sky`. Controls the accent colour on the team page.
+
+No page body for team members.
+
+## NotionAI scaffold prompt
+
+> Create a database called "Team" with these properties:
+> - Name (title)
+> - Role FR (text)
+> - Role EN (text)
+> - Track (select) — options: architect, builder, expert-engineer
+> - Avatar (files & media)
+> - Bio FR (text)
+> - Bio EN (text)
+> - LinkedIn (URL)
+> - Display order (number)
+> - Active (checkbox)
+> - Featured on about us (checkbox)
+> - Color (select) — options: yellow, coral, sky
+
+## Sample page
+
+| Property | Value |
+|----------|-------|
+| Name | Alice Dupont |
+| Role FR | Associée |
+| Role EN | Partner |
+| Track | architect |
+| Avatar | [alice.jpg] |
+| Bio FR | Alice accompagne les équipes RevOps depuis 10 ans. |
+| Bio EN | Alice has been supporting RevOps teams for 10 years. |
+| LinkedIn | https://linkedin.com/in/alice-dupont |
+| Active | ✓ |
+| Color | coral |

--- a/docs/notion-templates/tool.md
+++ b/docs/notion-templates/tool.md
@@ -1,0 +1,35 @@
+# Tool — Notion template
+
+## Property mapping
+
+| Notion property | Notion type | Frontmatter field | Required |
+|----------------|-------------|-------------------|----------|
+| Name | Title | `name` | ✅ |
+| Category | Select | `category` | ✅ |
+| Icon URL | Files & media | `iconUrl` | optional |
+
+**Accepted aliases:**
+- Name → `Nom`
+- Category → `Catégorie`
+- Icon URL → `Icon`, `IconUrl`
+
+**Category** — warn on new values during interview (show existing categories). Category is a free-form string, not a fixed enum.
+
+**Icon URL** — upload the tool icon as a Notion file attachment or external URL. The adapter downloads it to `assets/tools/<slug>.<ext>` during import.
+
+No page body for tools.
+
+## NotionAI scaffold prompt
+
+> Create a database called "Tools" with these properties:
+> - Name (title) — the tool display name, e.g. HubSpot
+> - Category (select) — e.g. CRM, Analytics, Automation
+> - Icon URL (files & media)
+
+## Sample page
+
+| Property | Value |
+|----------|-------|
+| Name | HubSpot |
+| Category | CRM |
+| Icon URL | [hubspot.svg] |

--- a/scripts/__tests__/fixtures/notion-blog-post.json
+++ b/scripts/__tests__/fixtures/notion-blog-post.json
@@ -1,0 +1,46 @@
+{
+  "id": "abc123",
+  "properties": {
+    "Title": {
+      "type": "title",
+      "title": [{ "plain_text": "Comment Yousign a transformé sa RevOps" }]
+    },
+    "Author": {
+      "type": "select",
+      "select": { "name": "jerome-boileux" }
+    },
+    "Description": {
+      "type": "rich_text",
+      "rich_text": [{ "plain_text": "Un retour d'expérience sur la structuration RevOps." }]
+    },
+    "Date": {
+      "type": "date",
+      "date": { "start": "2024-03-15" }
+    },
+    "Image": {
+      "type": "files",
+      "files": [
+        {
+          "name": "cover.jpg",
+          "type": "file",
+          "file": { "url": "https://prod-files-secure.s3.us-west-2.amazonaws.com/cover.jpg" }
+        }
+      ]
+    },
+    "Tags": {
+      "type": "multi_select",
+      "multi_select": [
+        { "name": "strategy" },
+        { "name": "ops" }
+      ]
+    },
+    "Read": {
+      "type": "rich_text",
+      "rich_text": [{ "plain_text": "6 min" }]
+    },
+    "Lang": {
+      "type": "select",
+      "select": { "name": "fr" }
+    }
+  }
+}

--- a/scripts/__tests__/fixtures/notion-story.json
+++ b/scripts/__tests__/fixtures/notion-story.json
@@ -1,0 +1,49 @@
+{
+  "id": "def456",
+  "properties": {
+    "Name": {
+      "type": "title",
+      "title": [{ "plain_text": "Yousign" }]
+    },
+    "Date": {
+      "type": "date",
+      "date": { "start": "2024-01-10" }
+    },
+    "Title": {
+      "type": "rich_text",
+      "rich_text": [{ "plain_text": "De 0 à une équipe RevOps en 18 mois" }]
+    },
+    "Subtitle": {
+      "type": "rich_text",
+      "rich_text": [{ "plain_text": "Startup SaaS spécialisée dans la signature électronique" }]
+    },
+    "Description": {
+      "type": "rich_text",
+      "rich_text": [{ "plain_text": "Yousign accompagne des milliers d'entreprises dans leur dématérialisation." }]
+    },
+    "Speaker": {
+      "type": "rich_text",
+      "rich_text": [{ "plain_text": "Jean Dupont" }]
+    },
+    "Role": {
+      "type": "rich_text",
+      "rich_text": [{ "plain_text": "Head of Revenue" }]
+    },
+    "Duration": {
+      "type": "rich_text",
+      "rich_text": [{ "plain_text": "6 mois" }]
+    },
+    "Scopes": {
+      "type": "multi_select",
+      "multi_select": [{ "name": "Acquisition" }, { "name": "CRM" }]
+    },
+    "Tools": {
+      "type": "multi_select",
+      "multi_select": [{ "name": "hubspot" }, { "name": "gsheet" }]
+    },
+    "Featured tool": {
+      "type": "select",
+      "select": { "name": "hubspot" }
+    }
+  }
+}

--- a/scripts/__tests__/fixtures/notion-team-member.json
+++ b/scripts/__tests__/fixtures/notion-team-member.json
@@ -1,0 +1,51 @@
+{
+  "id": "ghi789",
+  "properties": {
+    "Name": {
+      "type": "title",
+      "title": [{ "plain_text": "Alice Dupont" }]
+    },
+    "Role FR": {
+      "type": "rich_text",
+      "rich_text": [{ "plain_text": "Associée" }]
+    },
+    "Role EN": {
+      "type": "rich_text",
+      "rich_text": [{ "plain_text": "Partner" }]
+    },
+    "Track": {
+      "type": "select",
+      "select": { "name": "architect" }
+    },
+    "Avatar": {
+      "type": "files",
+      "files": [
+        {
+          "name": "alice.jpg",
+          "type": "external",
+          "external": { "url": "https://example.com/alice.jpg" }
+        }
+      ]
+    },
+    "Bio FR": {
+      "type": "rich_text",
+      "rich_text": [{ "plain_text": "Alice accompagne les équipes RevOps depuis 10 ans." }]
+    },
+    "Bio EN": {
+      "type": "rich_text",
+      "rich_text": [{ "plain_text": "Alice has been supporting RevOps teams for 10 years." }]
+    },
+    "LinkedIn": {
+      "type": "url",
+      "url": "https://linkedin.com/in/alice-dupont"
+    },
+    "Active": {
+      "type": "checkbox",
+      "checkbox": true
+    },
+    "Color": {
+      "type": "select",
+      "select": { "name": "coral" }
+    }
+  }
+}

--- a/scripts/__tests__/notion.adapter.test.js
+++ b/scripts/__tests__/notion.adapter.test.js
@@ -108,6 +108,23 @@ describe('mapNotionPage — team-member', () => {
     expect(fields.linkedin).toBe('https://linkedin.com/in/alice-dupont');
     expect(fields.color).toBe('coral');
   });
+
+  it('preserves active: false — does not drop falsy checkbox', () => {
+    const page = {
+      properties: {
+        Name: { type: 'title', title: [{ plain_text: 'Bob' }] },
+        'Role FR': { type: 'rich_text', rich_text: [{ plain_text: 'Consultant' }] },
+        'Role EN': { type: 'rich_text', rich_text: [{ plain_text: 'Consultant' }] },
+        Track: { type: 'select', select: { name: 'builder' } },
+        Avatar: { type: 'url', url: 'https://example.com/bob.jpg' },
+        'Bio FR': { type: 'rich_text', rich_text: [{ plain_text: 'Bio FR.' }] },
+        'Bio EN': { type: 'rich_text', rich_text: [{ plain_text: 'Bio EN.' }] },
+        Active: { type: 'checkbox', checkbox: false },
+      },
+    };
+    const { fields } = mapNotionPage(page, 'team-member');
+    expect(fields.active).toBe(false);
+  });
 });
 
 // ── mapNotionPage — tool / job (inline fixtures) ──────────────────────────────
@@ -171,6 +188,11 @@ describe('mapNotionPage — edge cases', () => {
     expect(Object.keys(fields)).toHaveLength(0);
     expect(body).toBe('');
     expect(assets).toHaveLength(0);
+  });
+
+  it('does not crash when a property value is null', () => {
+    const page = { properties: { Title: null, Author: { type: 'select', select: { name: 'alice' } } } };
+    expect(() => mapNotionPage(page, 'blog-post')).not.toThrow();
   });
 
   it('takes first file URL when multiple files present', () => {

--- a/scripts/__tests__/notion.adapter.test.js
+++ b/scripts/__tests__/notion.adapter.test.js
@@ -1,0 +1,207 @@
+import { join } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { mapNotionPage, extractAssets } from '../source-adapters/notion.js';
+
+const FIXTURES = join(fileURLToPath(import.meta.url), '..', 'fixtures');
+
+const loadFixture = async (name) => {
+  const raw = await readFile(join(FIXTURES, name), 'utf8');
+  return JSON.parse(raw);
+};
+
+// ── mapNotionPage — blog-post ─────────────────────────────────────────────────
+
+describe('mapNotionPage — blog-post', () => {
+  it('maps all present properties to fields', async () => {
+    const page = await loadFixture('notion-blog-post.json');
+    const { fields } = mapNotionPage(page, 'blog-post');
+
+    expect(fields.title).toBe('Comment Yousign a transformé sa RevOps');
+    expect(fields.author).toBe('jerome-boileux');
+    expect(fields.description).toBe('Un retour d\'expérience sur la structuration RevOps.');
+    expect(fields.date).toBe('2024-03-15');
+    expect(fields.image).toBe('https://prod-files-secure.s3.us-west-2.amazonaws.com/cover.jpg');
+    expect(fields.tags).toEqual(['strategy', 'ops']);
+    expect(fields.read).toBe('6 min');
+    expect(fields.lang).toBe('fr');
+  });
+
+  it('excludes undefined optional fields', async () => {
+    const page = await loadFixture('notion-blog-post.json');
+    const { fields } = mapNotionPage(page, 'blog-post');
+    expect(fields.exerpt).toBeUndefined();
+    expect(fields.podcastId).toBeUndefined();
+  });
+
+  it('includes body from second arg', async () => {
+    const page = await loadFixture('notion-blog-post.json');
+    const { body } = mapNotionPage(page, 'blog-post', '  Corps de l\'article.  ');
+    expect(body).toBe('Corps de l\'article.');
+  });
+
+  it('returns empty body when not provided', async () => {
+    const page = await loadFixture('notion-blog-post.json');
+    const { body } = mapNotionPage(page, 'blog-post');
+    expect(body).toBe('');
+  });
+
+  it('extracts image into assets array', async () => {
+    const page = await loadFixture('notion-blog-post.json');
+    const { assets } = mapNotionPage(page, 'blog-post');
+    expect(assets).toHaveLength(1);
+    expect(assets[0].field).toBe('Image');
+    expect(assets[0].url).toContain('cover.jpg');
+  });
+});
+
+// ── mapNotionPage — story ─────────────────────────────────────────────────────
+
+describe('mapNotionPage — story', () => {
+  it('maps all present properties', async () => {
+    const page = await loadFixture('notion-story.json');
+    const { fields } = mapNotionPage(page, 'story');
+
+    expect(fields.name).toBe('Yousign');
+    expect(fields.date).toBe('2024-01-10');
+    expect(fields.title).toBe('De 0 à une équipe RevOps en 18 mois');
+    expect(fields.scopes).toEqual(['Acquisition', 'CRM']);
+    expect(fields.tools).toEqual(['hubspot', 'gsheet']);
+    expect(fields.featuredTool).toBe('hubspot');
+  });
+
+  it('excludes optional fields not set in Notion', async () => {
+    const page = await loadFixture('notion-story.json');
+    const { fields } = mapNotionPage(page, 'story');
+    expect(fields.quotes).toBeUndefined();
+    expect(fields.deliverables).toBeUndefined();
+    expect(fields.lang).toBeUndefined();
+  });
+});
+
+// ── mapNotionPage — team-member ───────────────────────────────────────────────
+
+describe('mapNotionPage — team-member', () => {
+  it('assembles nested role and bio objects', async () => {
+    const page = await loadFixture('notion-team-member.json');
+    const { fields } = mapNotionPage(page, 'team-member');
+
+    expect(fields.role).toEqual({ fr: 'Associée', en: 'Partner' });
+    expect(fields.bio).toEqual({
+      fr: 'Alice accompagne les équipes RevOps depuis 10 ans.',
+      en: 'Alice has been supporting RevOps teams for 10 years.',
+    });
+  });
+
+  it('extracts avatar from external files property', async () => {
+    const page = await loadFixture('notion-team-member.json');
+    const { fields, assets } = mapNotionPage(page, 'team-member');
+    expect(fields.avatar).toBe('https://example.com/alice.jpg');
+    expect(assets.some((a) => a.field === 'Avatar')).toBe(true);
+  });
+
+  it('maps checkbox and url properties', async () => {
+    const page = await loadFixture('notion-team-member.json');
+    const { fields } = mapNotionPage(page, 'team-member');
+    expect(fields.active).toBe(true);
+    expect(fields.linkedin).toBe('https://linkedin.com/in/alice-dupont');
+    expect(fields.color).toBe('coral');
+  });
+});
+
+// ── mapNotionPage — tool / job (inline fixtures) ──────────────────────────────
+
+describe('mapNotionPage — tool', () => {
+  const toolPage = {
+    id: 't1',
+    properties: {
+      Name: { type: 'title', title: [{ plain_text: 'HubSpot' }] },
+      Category: { type: 'select', select: { name: 'CRM' } },
+    },
+  };
+
+  it('maps name and category', () => {
+    const { fields } = mapNotionPage(toolPage, 'tool');
+    expect(fields.name).toBe('HubSpot');
+    expect(fields.category).toBe('CRM');
+  });
+
+  it('returns empty assets when no files property', () => {
+    const { assets } = mapNotionPage(toolPage, 'tool');
+    expect(assets).toHaveLength(0);
+  });
+});
+
+describe('mapNotionPage — job', () => {
+  const jobPage = {
+    id: 'j1',
+    properties: {
+      Title: { type: 'title', title: [{ plain_text: 'RevOps Manager' }] },
+      'Contract type': { type: 'select', select: { name: 'CDI' } },
+      Seniority: { type: 'rich_text', rich_text: [{ plain_text: '3-5 ans' }] },
+      Location: { type: 'rich_text', rich_text: [{ plain_text: 'Paris' }] },
+      'Start date': { type: 'date', date: { start: '2024-09-01' } },
+      'Hiring contact': { type: 'select', select: { name: 'alice' } },
+      'Tally form ID': { type: 'rich_text', rich_text: [{ plain_text: 'abc123' }] },
+      Status: { type: 'select', select: { name: 'published' } },
+      'Published at': { type: 'date', date: { start: '2024-08-01' } },
+    },
+  };
+
+  it('maps all required job fields', () => {
+    const { fields } = mapNotionPage(jobPage, 'job');
+    expect(fields.title).toBe('RevOps Manager');
+    expect(fields.contractType).toBe('CDI');
+    expect(fields.startDate).toBe('2024-09-01');
+    expect(fields.hiringContact).toBe('alice');
+    expect(fields.status).toBe('published');
+  });
+});
+
+// ── mapNotionPage — edge cases ────────────────────────────────────────────────
+
+describe('mapNotionPage — edge cases', () => {
+  it('throws on unknown type', () => {
+    expect(() => mapNotionPage({ properties: {} }, 'unknown')).toThrow('Unknown content type: unknown');
+  });
+
+  it('handles missing properties gracefully (empty page)', () => {
+    const { fields, body, assets } = mapNotionPage({}, 'blog-post');
+    expect(Object.keys(fields)).toHaveLength(0);
+    expect(body).toBe('');
+    expect(assets).toHaveLength(0);
+  });
+
+  it('takes first file URL when multiple files present', () => {
+    const page = {
+      properties: {
+        Image: {
+          type: 'files',
+          files: [
+            { type: 'file', file: { url: 'https://example.com/first.jpg' } },
+            { type: 'file', file: { url: 'https://example.com/second.jpg' } },
+          ],
+        },
+      },
+    };
+    const { fields } = mapNotionPage(page, 'blog-post');
+    expect(fields.image).toBe('https://example.com/first.jpg');
+  });
+});
+
+// ── extractAssets ─────────────────────────────────────────────────────────────
+
+describe('extractAssets', () => {
+  it('returns one entry per file URL across all files properties', async () => {
+    const page = await loadFixture('notion-blog-post.json');
+    const assets = extractAssets(page);
+    expect(assets).toHaveLength(1);
+    expect(assets[0]).toMatchObject({ field: 'Image', url: expect.stringContaining('cover.jpg') });
+  });
+
+  it('returns empty array when no files properties', () => {
+    const page = { properties: { Title: { type: 'title', title: [] } } };
+    expect(extractAssets(page)).toHaveLength(0);
+  });
+});

--- a/scripts/source-adapters/notion.js
+++ b/scripts/source-adapters/notion.js
@@ -11,8 +11,8 @@ const EXTRACTORS = {
   date: (p) => p.date?.start ?? '',
   url: (p) => p.url ?? '',
   email: (p) => p.email ?? '',
-  number: (p) => p.number ?? null,
-  checkbox: (p) => p.checkbox ?? false,
+  number: (p) => (p.number !== undefined ? p.number : undefined),
+  checkbox: (p) => (p.checkbox !== undefined ? p.checkbox : undefined),
   files: (p) =>
     p.files?.map((f) => f.file?.url ?? f.external?.url).filter(Boolean) ?? [],
 };
@@ -63,7 +63,6 @@ const MAPPINGS = {
     featuredTool: extractSingle(props, 'Featured tool', 'Outil principal', 'Featured Tool'),
     quotes: extractProp(props, 'Quotes', 'Citations'),
     deliverables: extractProp(props, 'Deliverables', 'Livrables'),
-    lang: extractProp(props, 'Lang', 'Language', 'Langue'),
   }),
 
   'team-member': (props) => ({
@@ -111,7 +110,7 @@ const compactFields = (fields) =>
     Object.entries(fields).filter(([, v]) => {
       if (v === undefined || v === null || v === '') return false;
       if (Array.isArray(v) && v.length === 0) return false;
-      return true;
+      return true; // preserves false and 0
     }),
   );
 
@@ -134,10 +133,9 @@ const nestFields = (flat) => {
 export const extractAssets = (page) => {
   const assets = [];
   for (const [field, prop] of Object.entries(page.properties ?? {})) {
-    if (prop.type === 'files') {
-      for (const url of EXTRACTORS.files(prop)) {
-        assets.push({ field, url });
-      }
+    if (!prop || prop.type !== 'files') continue;
+    for (const url of EXTRACTORS.files(prop)) {
+      assets.push({ field, url });
     }
   }
   return assets;

--- a/scripts/source-adapters/notion.js
+++ b/scripts/source-adapters/notion.js
@@ -1,0 +1,178 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+// ── Notion property extractors ────────────────────────────────────────────────
+
+const EXTRACTORS = {
+  title: (p) => p.title?.map((r) => r.plain_text).join('') ?? '',
+  rich_text: (p) => p.rich_text?.map((r) => r.plain_text).join('') ?? '',
+  select: (p) => p.select?.name ?? '',
+  multi_select: (p) => p.multi_select?.map((o) => o.name) ?? [],
+  date: (p) => p.date?.start ?? '',
+  url: (p) => p.url ?? '',
+  email: (p) => p.email ?? '',
+  number: (p) => p.number ?? null,
+  checkbox: (p) => p.checkbox ?? false,
+  files: (p) =>
+    p.files?.map((f) => f.file?.url ?? f.external?.url).filter(Boolean) ?? [],
+};
+
+const extractProp = (properties, ...aliases) => {
+  for (const alias of aliases) {
+    const prop = properties[alias];
+    if (!prop) continue;
+    const extractor = EXTRACTORS[prop.type];
+    if (extractor) return extractor(prop);
+  }
+  return undefined;
+};
+
+// For fields that expect a single value but may come from a files/multi_select property
+const extractSingle = (properties, ...aliases) => {
+  const val = extractProp(properties, ...aliases);
+  return Array.isArray(val) ? val[0] : val;
+};
+
+// ── Per-type property → field mappings ────────────────────────────────────────
+
+const MAPPINGS = {
+  'blog-post': (props) => ({
+    title: extractProp(props, 'Title', 'Titre', 'Name'),
+    author: extractProp(props, 'Author', 'Auteur'),
+    description: extractProp(props, 'Description'),
+    date: extractProp(props, 'Date'),
+    image: extractSingle(props, 'Image', 'Cover', 'Couverture'),
+    exerpt: extractProp(props, 'Exerpt', 'Excerpt', 'Résumé'),
+    read: extractProp(props, 'Read', 'Reading time', 'Temps de lecture'),
+    podcastId: extractProp(props, 'Podcast ID', 'PodcastId', 'Podcast'),
+    tags: extractProp(props, 'Tags'),
+    lang: extractProp(props, 'Lang', 'Language', 'Langue'),
+  }),
+
+  story: (props) => ({
+    name: extractProp(props, 'Name', 'Client', 'Nom'),
+    date: extractProp(props, 'Date'),
+    title: extractProp(props, 'Title', 'Titre'),
+    subtitle: extractProp(props, 'Subtitle', 'Sous-titre'),
+    description: extractProp(props, 'Description'),
+    speaker: extractProp(props, 'Speaker', 'Contact', 'Interlocuteur'),
+    role: extractProp(props, 'Role', 'Rôle', 'Job title'),
+    duration: extractProp(props, 'Duration', 'Durée'),
+    scopes: extractProp(props, 'Scopes', 'Périmètres'),
+    tools: extractProp(props, 'Tools', 'Outils'),
+    featuredTool: extractSingle(props, 'Featured tool', 'Outil principal', 'Featured Tool'),
+    quotes: extractProp(props, 'Quotes', 'Citations'),
+    deliverables: extractProp(props, 'Deliverables', 'Livrables'),
+    lang: extractProp(props, 'Lang', 'Language', 'Langue'),
+  }),
+
+  'team-member': (props) => ({
+    name: extractProp(props, 'Name', 'Nom'),
+    'role.fr': extractProp(props, 'Role FR', 'Rôle FR', 'Role (FR)'),
+    'role.en': extractProp(props, 'Role EN', 'Role (EN)'),
+    track: extractProp(props, 'Track'),
+    avatar: extractSingle(props, 'Avatar', 'Photo'),
+    'bio.fr': extractProp(props, 'Bio FR', 'Bio (FR)'),
+    'bio.en': extractProp(props, 'Bio EN', 'Bio (EN)'),
+    linkedin: extractProp(props, 'LinkedIn', 'Linkedin'),
+    displayOrder: extractProp(props, 'Display order', 'Order', 'Ordre'),
+    active: extractProp(props, 'Active'),
+    featuredOnAboutUs: extractProp(props, 'Featured on about us', 'Featured'),
+    color: extractProp(props, 'Color', 'Couleur'),
+  }),
+
+  tool: (props) => ({
+    name: extractProp(props, 'Name', 'Nom'),
+    category: extractProp(props, 'Category', 'Catégorie'),
+    iconUrl: extractSingle(props, 'Icon URL', 'Icon', 'IconUrl'),
+  }),
+
+  job: (props) => ({
+    title: extractProp(props, 'Title', 'Titre', 'Name'),
+    icon: extractProp(props, 'Icon', 'Icône'),
+    contractType: extractProp(props, 'Contract type', 'Type de contrat'),
+    seniority: extractProp(props, 'Seniority', 'Séniorité'),
+    location: extractProp(props, 'Location', 'Lieu'),
+    startDate: extractProp(props, 'Start date', 'Date de début'),
+    hiringContact: extractProp(props, 'Hiring contact', 'Contact RH'),
+    applyEmail: extractProp(props, 'Apply email', 'Email candidature'),
+    tallyFormId: extractProp(props, 'Tally form ID', 'TallyFormId'),
+    status: extractProp(props, 'Status', 'Statut'),
+    publishedAt: extractProp(props, 'Published at', 'Date de publication'),
+    intro: extractProp(props, 'Intro'),
+    lang: extractProp(props, 'Lang', 'Language', 'Langue'),
+  }),
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const compactFields = (fields) =>
+  Object.fromEntries(
+    Object.entries(fields).filter(([, v]) => {
+      if (v === undefined || v === null || v === '') return false;
+      if (Array.isArray(v) && v.length === 0) return false;
+      return true;
+    }),
+  );
+
+// Converts dot-notation keys (role.fr, bio.en) into nested objects
+const nestFields = (flat) => {
+  const result = {};
+  for (const [key, value] of Object.entries(flat)) {
+    if (key.includes('.')) {
+      const [parent, child] = key.split('.');
+      result[parent] = { ...result[parent], [child]: value };
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+};
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+export const extractAssets = (page) => {
+  const assets = [];
+  for (const [field, prop] of Object.entries(page.properties ?? {})) {
+    if (prop.type === 'files') {
+      for (const url of EXTRACTORS.files(prop)) {
+        assets.push({ field, url });
+      }
+    }
+  }
+  return assets;
+};
+
+export const mapNotionPage = (page, type, body = '') => {
+  const mapper = MAPPINGS[type];
+  if (!mapper) throw new Error(`Unknown content type: ${type}`);
+
+  const raw = mapper(page.properties ?? {});
+  const fields = nestFields(compactFields(raw));
+  const assets = extractAssets(page);
+
+  return { fields, body: body.trim(), assets };
+};
+
+// ── CLI: node scripts/source-adapters/notion.js <page-json-path> <type> [body-path] ──
+
+const __filename = fileURLToPath(import.meta.url);
+if (process.argv[1] === __filename) {
+  const [, , pageJsonPath, type, bodyPath] = process.argv;
+  if (!pageJsonPath || !type) {
+    console.error(
+      'Usage: node scripts/source-adapters/notion.js <page-json-path> <type> [body-path]',
+    );
+    process.exit(1);
+  }
+  try {
+    const pageJson = await readFile(pageJsonPath, 'utf8');
+    const page = JSON.parse(pageJson);
+    const body = bodyPath ? await readFile(bodyPath, 'utf8') : '';
+    const result = mapNotionPage(page, type, body);
+    console.log(JSON.stringify(result, null, 2));
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/source-adapters/notion.js` — pure mapper from Notion REST API page object to `{fields, body, assets[]}`. Handles 10 Notion property types (title, rich_text, select, multi_select, date, url, email, number, checkbox, files), alias fallbacks per field, dot-notation nesting for `role.fr`/`bio.en`, and single-value coercion for image/avatar/iconUrl.
- Adds 3 JSON fixtures + 18 Vitest tests covering all 5 types, edge cases (empty page, unknown type, multi-file coercion), and asset extraction.
- Extends `.claude/skills/new-content/SKILL.md`: Step 0 now dispatches on source type (Notion URL vs local file path), Step 0A walks the full Notion fetch → notion.js → image download flow with graceful fallback when MCP is not configured.
- Adds `docs/mcp-notion-setup.md` — followable from a fresh machine.
- Adds `docs/notion-templates/` — README + one file per type with property mapping table, NotionAI scaffold prompt, and sample page.

## Acceptance criteria

- [x] `new-content https://notion.so/...` — Step 0 detects Notion URL, calls notion-fetch MCP, runs notion.js
- [x] Images from `files` properties land in `assets[]` for download
- [x] `docs/mcp-notion-setup.md` is self-contained from a fresh machine
- [x] Each `docs/notion-templates/<type>.md` has a NotionAI prompt
- [x] Without Notion MCP, skill shows a clear message and falls back to interview/local-file mode
- [x] `pnpm test` passes (162 tests, 8 files)

Closes #25