### PR TITLE
fix(team): set Clémentine du Pradel track to architect

### DIFF
--- a/team/clementine-du-pradel.md
+++ b/team/clementine-du-pradel.md
@@ -1,7 +1,7 @@
 ---
 slug: clementine-du-pradel
 name: Clémentine du Pradel
-track: Manager
+track: architect
 avatar: assets/team/clementine-du-pradel.png
 role:
   fr: Manager


### PR DESCRIPTION
## Summary
- Corrects `track` field from `Manager` to `architect` on Clémentine du Pradel's profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)