### PR TITLE
docs: content authoring entry point (CLAUDE.md + README)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,3 +15,21 @@ Default Pocock label vocabulary, one-to-one with canonical roles. See `docs/agen
 ### Domain docs
 
 Single-context. `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+
+### Content authoring
+
+Three skills cover the full authoring lifecycle:
+
+- `new-content` (`.claude/skills/new-content/`) — create any of the 5 types (`blog-post | story | team-member | tool | job`). Source-agnostic: interview, local file, or Notion URL.
+- `publish-content` — validate and open a PR against `main`.
+- `translate-content` — translate an existing file to the other language.
+
+Canonical workflow: `/new-content [--type X] [source]` → review preview → `/publish-content`. Source modes: **interview** (no setup), **local file** (`/new-content draft.md`), **Notion URL** (optional MCP, see `docs/mcp-notion-setup.md`).
+
+Traps to respect when editing content directly:
+
+- **`exerpt`** — the blog frontmatter key is intentionally misspelled; perpetuate it, do not "fix" it.
+- **Slugs are identity** — kebab-case, and the cross-reference key for authors, tools, hiringContacts. Renaming a slug breaks references.
+- **Blob URLs** — image fields (`avatar`, `image`, `iconUrl`) must resolve to Vercel Blob URLs; CI rewrites local paths on PR. `pnpm validate` fails on local paths until then — expected pre-sync.
+- **Multi-language paradigm** — blog/story/job live under `<type>/<lang>/<slug>.md` (`fr` default). Team members carry both languages inline (`role.fr/en`, `bio.fr/en`); tools are language-agnostic (`name`, `category`, no translatable copy). Neither has a per-lang directory.
+- **Cross-refs are strict** — `author`, `tools`, `featuredTool`, `hiringContact` must point to existing slugs; validation rejects dangling references.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,36 @@ For the full architecture (system diagram, content flow, asset flow, repo-bounda
 
 ---
 
+## Adding content
+
+Content is authored through three Claude Code skills — no CMS, no manual frontmatter.
+
+### Prerequisites
+
+```bash
+pnpm install
+```
+
+That's all you need to start. Notion import is **optional** — if you want to pull a draft from a Notion page, follow [`docs/mcp-notion-setup.md`](docs/mcp-notion-setup.md) to connect the Notion MCP. Otherwise, interview mode works immediately.
+
+### The three commands
+
+| Command | Purpose |
+|---------|---------|
+| `/new-content [--type X] [source]` | Create a new blog post, story, team member, tool, or job. |
+| `/publish-content` | Validate the new file and open a PR against `main`. |
+| `/translate-content` | Translate an existing content file to the other language. |
+
+Canonical flow: **`/new-content` → review the preview → `/publish-content`**. CI uploads assets to Vercel Blob and rewrites local image paths to Blob URLs on the PR, then runs `pnpm validate` as a required check.
+
+### Three source modes for `/new-content`
+
+1. **Interview** — `/new-content` (or `/new-content --type blog-post`). Claude walks you through the required fields. No external source needed.
+2. **Local file** — `/new-content path/to/draft.md`. Pre-fills fields from a local markdown draft; the interview only asks for what's missing.
+3. **Notion URL** — `/new-content https://notion.so/...`. Pre-fills from a Notion page (requires the optional MCP setup above).
+
+---
+
 ## Asset Management
 
 This repository includes tools for managing assets independently from the main website deployment.


### PR DESCRIPTION
## Slice #29 — final documentation entry point

Closes #29.

- **README.md** — new "Adding content" section above "Asset Management": prereqs (`pnpm install`, optional Notion MCP), the three commands, the three source modes. Interview mode works with no MCP setup.
- **CLAUDE.md** — "Content authoring" subsection: points to the three skills, the canonical workflow, the three source modes, and the five content traps (`exerpt` typo, slug identity, Blob URLs, multi-language paradigm, strict cross-refs).

No duplication with `CONTEXT.md` or the ADRs — both files point to canonical references.

This is the last open slice of milestone #1.