### PR TITLE
fix(ci): run content-sync on all PRs, not only content paths

### DIFF
--- a/.github/workflows/content-sync.yml
+++ b/.github/workflows/content-sync.yml
@@ -1,15 +1,11 @@
 name: Content sync
 
 on:
+  # Runs on every PR. `sync-and-validate` is a required status check on `main`;
+  # a path filter here would mean PRs that touch no content path (docs, config)
+  # never report the check and can never merge. The upload step no-ops when no
+  # assets changed, so docs-only PRs just run `pnpm validate` and pass.
   pull_request:
-    paths:
-      - 'team/**'
-      - 'blog/**'
-      - 'stories/**'
-      - 'jobs/**'
-      - 'tools/**'
-      - 'assets/**'
-      - '.github/workflows/**'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Problem

`sync-and-validate` (from `content-sync.yml`) is a **required** status check on `main`. The workflow had a `pull_request` path filter limited to content/asset paths. Any PR that touches none of those paths (docs, config) never triggers the workflow, so the required check is never reported and the PR is **permanently unmergeable** — e.g. #62 (CLAUDE.md + README only).

## Fix

Remove the path filter so the workflow runs on every PR. The upload step already no-ops when no new assets are present (`uploaded=false` → URL-rewrite skipped), so a docs-only PR simply runs `pnpm validate` (fast) and reports green.

## Note

This PR touches `.github/workflows/**`, which *is* in the current filter — so it self-triggers content-sync and validates before merge. After merge, re-trigger #62 (rebase) to pick up the filter-free config.