### PR TITLE
feat(setup): add macOS onboarding skill for content contributors

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -1,0 +1,157 @@
+# setup
+
+Take a brand-new macOS contributor from a fresh machine to "ready to run `/new-content`" — install and connect everything this repo needs to author content and open PRs.
+
+## When to invoke
+
+When someone on macOS is setting up this repo for the first time and wants the content-authoring workflow working end to end. Scope is deliberately narrow: **macOS + Homebrew**, and **this repo only** — authoring content and opening PRs against `ocobo-revops/posts`. No website repo, no broader Ocobo tooling.
+
+## How to behave
+
+The contributor may be **non-technical**. Run the diagnostic commands for them, read the output, and explain what you find in plain language. Never make them paste commands they don't understand.
+
+**Be idempotent — check before you install.** For every prerequisite, detect what's already present first and skip it. Never reinstall blindly. Tell the user "already installed (vX.Y) ✓" or "missing — installing now".
+
+Work through the steps in order. If a step fails, stop, show the error, and resolve it before moving on — a later step usually depends on an earlier one.
+
+## 1. Homebrew
+
+```bash
+command -v brew && brew --version
+```
+
+If present, say so and continue. If missing, do **not** install it silently — point the user to the official command and let them run it (it prompts for the macOS password):
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+After install, follow Homebrew's printed instructions to add `brew` to the shell `PATH`, then re-check `brew --version`.
+
+## 2. Node.js 24
+
+CI pins Node 24 — match it locally.
+
+```bash
+node -v
+```
+
+If it already reports `v24.x`, skip. Otherwise:
+
+```bash
+brew install node@24
+```
+
+`node@24` is keg-only, so it isn't on `PATH` by default. **Use the exact path `brew install` prints** — it differs by Mac: `/opt/homebrew/opt/node@24/bin` on Apple Silicon, `/usr/local/opt/node@24/bin` on Intel. Append it to the shell profile, e.g. on Apple Silicon:
+
+```bash
+echo 'export PATH="/opt/homebrew/opt/node@24/bin:$PATH"' >> ~/.zshrc
+```
+
+Open a new shell, then verify:
+
+```bash
+node -v   # expect v24.x
+```
+
+## 3. pnpm 8
+
+CI pins pnpm 8 — this repo uses pnpm, not npm or yarn.
+
+```bash
+pnpm -v
+```
+
+If it already reports `8.x`, skip. Otherwise:
+
+```bash
+brew install pnpm
+pnpm -v   # expect 8.x
+```
+
+If `brew` installs a newer major (9.x, 10.x), that's fine for pure authoring — but warn the user that **changing dependencies** with a mismatched pnpm can regenerate `pnpm-lock.yaml` in a format CI's `--frozen-lockfile` (pinned to 8) rejects. If they only author content, the pin doesn't bite.
+
+## 4. GitHub CLI
+
+`publish-content` opens PRs with `gh`, so it must be installed **and authenticated**.
+
+```bash
+gh --version
+```
+
+If missing:
+
+```bash
+brew install gh
+```
+
+Then check auth — this is the part people skip:
+
+```bash
+gh auth status
+```
+
+If it reports not logged in, run the interactive login and walk the user through the browser prompts (choose GitHub.com → HTTPS → authenticate via browser):
+
+```bash
+gh auth login
+```
+
+Re-run `gh auth status` afterwards and confirm it shows a clean, logged-in state for `github.com` before continuing.
+
+## 5. Clone + install
+
+If you're not already inside the repo (`git remote -v` doesn't show `ocobo-revops/posts`), clone it into a directory the user picks:
+
+```bash
+gh repo clone ocobo-revops/posts
+cd posts
+```
+
+If already inside it, skip the clone. Either way, install dependencies to green:
+
+```bash
+pnpm install
+```
+
+If `pnpm install` fails, stop and show the error — do not proceed to validation.
+
+## 6. Claude Code + skills
+
+Confirm Claude Code is installed (the user is running it now if they reached this skill). Confirm the repo's authoring skills are discoverable:
+
+```bash
+ls .claude/skills/
+```
+
+You should see `new-content`, `publish-content`, `translate-content`, and `setup`. If they're missing, the clone or `cd` went wrong — re-check step 5.
+
+## 7. Notion MCP (optional)
+
+The Notion MCP lets `new-content` import pages directly from the Ocobo Notion workspace. **It is optional** — interview mode and local-file mode both work without it, so this is never a blocker.
+
+Offer it: "Want to set up Notion import? It's optional — you can author content without it." If yes, point the user to `docs/mcp-notion-setup.md` (it's a claude.ai Settings → Integrations flow, not a terminal step). If no, move on.
+
+## 8. No local Blob token
+
+Tell the user explicitly: **you do NOT need any Vercel Blob token locally.** Image upload to Vercel Blob is handled by CI when a PR is opened — the workflow uses a repo secret (`NEW_BLOB_READ_WRITE_TOKEN`), not anything on your machine. `pnpm validate` may flag local image paths before that sync runs — that's expected, not an error to fix.
+
+## You're ready
+
+Print a short summary of what's now in place, for example:
+
+```
+Setup complete ✓
+  Homebrew      ✓
+  Node          v24.x
+  pnpm          8.x
+  GitHub CLI    authenticated as <user>
+  Dependencies  installed
+  Skills        new-content, publish-content, translate-content, setup
+  Notion MCP    <connected | skipped (optional)>
+  Blob token    not needed locally — CI handles uploads
+
+Next: run /new-content to create your first piece of content.
+```
+
+Then tell them to run `/new-content` to start authoring.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,9 @@ Single-context. `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/do
 
 ### Content authoring
 
-Three skills cover the full authoring lifecycle:
+Four skills cover the full authoring lifecycle:
 
+- `setup` (`.claude/skills/setup/`) — one-command macOS onboarding for new contributors: installs/checks Homebrew, Node 24, pnpm 8, GitHub CLI auth, clones + installs, leaves the machine ready to run `/new-content`.
 - `new-content` (`.claude/skills/new-content/`) — create any of the 5 types (`blog-post | story | team-member | tool | job`). Source-agnostic: interview, local file, or Notion URL.
 - `publish-content` — validate and open a PR against `main`.
 - `translate-content` — translate an existing file to the other language.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For the full architecture (system diagram, content flow, asset flow, repo-bounda
 
 ## Adding content
 
-Content is authored through three Claude Code skills — no CMS, no manual frontmatter.
+Content is authored through Claude Code skills — no CMS, no manual frontmatter.
 
 ### Prerequisites
 
@@ -24,10 +24,13 @@ pnpm install
 
 That's all you need to start. Notion import is **optional** — if you want to pull a draft from a Notion page, follow [`docs/mcp-notion-setup.md`](docs/mcp-notion-setup.md) to connect the Notion MCP. Otherwise, interview mode works immediately.
 
-### The three commands
+**New contributor on a fresh macOS machine?** Run `/setup` in Claude Code — it installs and checks everything (Homebrew, Node 24, pnpm 8, GitHub CLI auth, dependencies) and leaves you ready to run `/new-content`.
+
+### The commands
 
 | Command | Purpose |
 |---------|---------|
+| `/setup` | One-time macOS onboarding — install/check Homebrew, Node 24, pnpm 8, GitHub CLI auth, dependencies. |
 | `/new-content [--type X] [source]` | Create a new blog post, story, team member, tool, or job. |
 | `/publish-content` | Validate the new file and open a PR against `main`. |
 | `/translate-content` | Translate an existing content file to the other language. |


### PR DESCRIPTION
## What

Adds a `setup` skill (`.claude/skills/setup/SKILL.md`) — one-command macOS onboarding that takes a brand-new, non-technical contributor from a fresh machine to "ready to run `/new-content`".

Closes #64.

## Scope

macOS + Homebrew, **this repo only** (authoring content + opening PRs against `ocobo-revops/posts`). No website repo, no broader Ocobo tooling.

## What the skill does

Idempotent — detects each prerequisite first and skips what's present, never reinstalls blindly:

1. **Homebrew** — detect; point to official install command if missing
2. **Node 24** — `brew install node@24` (CI pins Node 24)
3. **pnpm 8** — `brew install pnpm` (CI pins pnpm 8)
4. **GitHub CLI** — `brew install gh` + `gh auth login`, verified via `gh auth status` (required by `publish-content`)
5. **Clone + install** — clone if needed, `pnpm install` to green
6. **Claude Code skills** — confirm `.claude/skills/` discoverable
7. **Notion MCP (optional)** — points to `docs/mcp-notion-setup.md`, never a blocker
8. **No local Blob token** — explicitly states `BLOB_READ_WRITE_TOKEN` isn't needed locally; CI handles upload

Ends with a "you're ready" summary → run `/new-content`.

## Docs

- `CLAUDE.md` — content-authoring section now lists four skills
- `README.md` — adds `/setup` onboarding entry point + command table row

## Acceptance criteria

- [x] Installs Homebrew deps or detects them — never reinstalls blindly
- [x] `gh auth login` triggered and verified
- [x] Clones (if needed) and runs `pnpm install`
- [x] Notion MCP presented as optional → `docs/mcp-notion-setup.md`
- [x] States no local Blob token required
- [x] On completion, contributor can run `/new-content` in interview mode
- [x] Scope limited to macOS + this repo's authoring workflow