### PR TITLE
feat: optimize images in the publish flow before pushing (#66)

### DIFF
--- a/.claude/skills/publish-content/SKILL.md
+++ b/.claude/skills/publish-content/SKILL.md
@@ -31,6 +31,18 @@ Extract from the file path:
 - `jobs/fr/<slug>.md` → type `job`, lang `fr`
 - `jobs/en/<slug>.md` → type `job`, lang `en`
 
+## Optimize assets
+
+Run **before** sync so the optimized bytes are what get committed and uploaded to Vercel Blob:
+
+```bash
+pnpm optimize-assets:write
+```
+
+This re-encodes only the branch's new/changed images that exceed the 400 KB threshold (in place); smaller images are left byte-identical, and `.svg`/`.gif` are skipped. If there are no changed assets it prints "No changed assets to optimise." and is a no-op.
+
+Surface the concise before/after report it prints (files touched + bytes saved) so the contributor sees what changed. Do not tweak threshold or quality — the defaults are deliberate.
+
 ## Run sync-assets
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ assets/
 ✅ **No website rebuilds** when adding content assets  
 ✅ **CDN performance** for all images  
 ✅ **Independent workflows** for content and code  
-✅ **Automatic asset optimization** via Vercel Blob  
+✅ **Publish-time image optimization** — the `publish-content` skill runs `pnpm optimize-assets:write` over the branch's new/changed images before upload, re-encoding oversized ones (> 400 KB) in place (local only; not automatic on Vercel Blob, no CI step)  
 ✅ **Version control** for content and assets separately  
 
 ### Troubleshooting

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "sync-assets": "pnpm upload-assets && pnpm update-urls",
     "sync-assets:all": "pnpm upload-assets:all && pnpm update-urls",
     "sync-assets:migrate": "pnpm upload-assets:migrate && pnpm update-urls:new",
+    "optimize-assets": "node scripts/optimize-assets.js --changed",
+    "optimize-assets:write": "node scripts/optimize-assets.js --changed --write",
     "validate": "node scripts/validate-content.js",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/scripts/__tests__/optimize-assets.test.js
+++ b/scripts/__tests__/optimize-assets.test.js
@@ -12,6 +12,7 @@ import {
   parseArgs,
   resolveChangedPaths,
   resolvePaths,
+  resolveScope,
   run,
   writeAtomic,
 } from '../optimize-assets.js';
@@ -213,6 +214,36 @@ describe('resolveChangedPaths', () => {
     } finally {
       await rm(nonRepo, { recursive: true, force: true });
     }
+  });
+});
+
+describe('resolveScope', () => {
+  it('explicit --paths win over --changed (git is never consulted)', () => {
+    // rootDir is a non-existent, non-git path: if --changed were honoured it
+    // would surface the no-git warning. Explicit paths must short-circuit that.
+    const { paths, warning } = resolveScope({
+      changed: true,
+      explicitPaths: ['assets/team/jane.jpg'],
+      rootDir: '/nonexistent',
+    });
+
+    expect(paths).toEqual(['assets/team/jane.jpg']);
+    expect(warning).toBeNull();
+  });
+
+  it('with neither flag, paths is undefined so run() walks all assets', () => {
+    const { paths } = resolveScope({ changed: false, explicitPaths: undefined, rootDir: '/x' });
+    expect(paths).toBeUndefined();
+  });
+
+  it('--changed outside a git repo yields no paths and a warning (no mass rewrite)', () => {
+    const { paths, warning } = resolveScope({
+      changed: true,
+      explicitPaths: undefined,
+      rootDir: '/nonexistent',
+    });
+    expect(paths).toEqual([]);
+    expect(warning).toMatch(/git/i);
   });
 });
 

--- a/scripts/__tests__/optimize-assets.test.js
+++ b/scripts/__tests__/optimize-assets.test.js
@@ -1,3 +1,4 @@
+import { execSync } from 'node:child_process';
 import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -8,6 +9,8 @@ import {
   formatReport,
   getDirConfig,
   optimizeBuffer,
+  parseArgs,
+  resolveChangedPaths,
   resolvePaths,
   run,
   writeAtomic,
@@ -153,6 +156,75 @@ describe('resolvePaths', () => {
     expect(result.files).toEqual(['assets/team/jane.jpg']);
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]).toMatch(/missing\.jpg/);
+  });
+});
+
+describe('resolveChangedPaths', () => {
+  let rootDir;
+
+  const git = (cmd) =>
+    execSync(`git ${cmd}`, { cwd: rootDir, stdio: ['ignore', 'pipe', 'ignore'] });
+
+  beforeEach(async () => {
+    rootDir = await mkdtemp(join(tmpdir(), 'optimize-assets-changed-'));
+    git('init -q');
+    git('config user.email "test@example.com"');
+    git('config user.name "Test"');
+    git('commit --allow-empty -q -m "init"');
+    await mkdir(join(rootDir, 'assets', 'posts'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  it('returns only changed image paths, excluding non-images and unchanged files', async () => {
+    await writeFile(join(rootDir, 'assets', 'posts', 'committed.png'), 'v1');
+    git('add assets/posts/committed.png');
+    git('commit -q -m "add committed"');
+
+    await writeFile(join(rootDir, 'assets', 'posts', 'fresh.jpg'), 'jpg');
+    await writeFile(join(rootDir, 'assets', 'posts', 'notes.md'), 'md');
+
+    const result = resolveChangedPaths(rootDir);
+
+    expect(result.paths).toContain('assets/posts/fresh.jpg');
+    expect(result.paths).not.toContain('assets/posts/notes.md');
+    expect(result.paths).not.toContain('assets/posts/committed.png');
+    expect(result.warning).toBeNull();
+  });
+
+  it('excludes formats the optimizer cannot encode (.svg, .gif)', async () => {
+    await writeFile(join(rootDir, 'assets', 'posts', 'logo.svg'), 'svg');
+    await writeFile(join(rootDir, 'assets', 'posts', 'anim.gif'), 'gif');
+    await writeFile(join(rootDir, 'assets', 'posts', 'photo.jpg'), 'jpg');
+
+    const { paths } = resolveChangedPaths(rootDir);
+
+    expect(paths).toEqual(['assets/posts/photo.jpg']);
+  });
+
+  it('returns no paths and a warning outside a git repository (no mass rewrite)', async () => {
+    const nonRepo = await mkdtemp(join(tmpdir(), 'optimize-assets-nogit-'));
+    try {
+      const result = resolveChangedPaths(nonRepo);
+      expect(result.paths).toEqual([]);
+      expect(result.warning).toMatch(/git/i);
+    } finally {
+      await rm(nonRepo, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('parseArgs', () => {
+  const argv = (...flags) => ['node', 'optimize-assets.js', ...flags];
+
+  it('defaults changed to false', () => {
+    expect(parseArgs(argv()).changed).toBe(false);
+  });
+
+  it('sets changed when --changed is passed', () => {
+    expect(parseArgs(argv('--changed', '--write')).changed).toBe(true);
   });
 });
 

--- a/scripts/optimize-assets.js
+++ b/scripts/optimize-assets.js
@@ -94,6 +94,14 @@ export const resolveChangedPaths = (rootDir) => {
   return { paths, warning: null };
 };
 
+// Decide which files the CLI should process. Explicit --paths always wins over
+// --changed; with neither, paths is undefined so run() walks all of assets/**.
+export const resolveScope = ({ changed, explicitPaths, rootDir }) => {
+  if (explicitPaths) return { paths: explicitPaths, warning: null };
+  if (changed) return resolveChangedPaths(rootDir);
+  return { paths: undefined, warning: null };
+};
+
 const DIR_LIMITS = [
   ['assets/team/', 800],
   ['assets/clients/', 400],
@@ -316,16 +324,11 @@ if (isMainModule()) {
 
   // --changed scopes to the branch's new/changed assets (publish flow). Explicit
   // --paths wins if both are given; bare invocation still walks assets/**.
-  let paths = explicitPaths;
-  let changedWarning;
-  if (changed && !explicitPaths) {
-    const resolved = resolveChangedPaths(rootDir);
-    paths = resolved.paths;
-    changedWarning = resolved.warning;
-  }
+  const { paths, warning: changedWarning } = resolveScope({ changed, explicitPaths, rootDir });
 
+  const fromChanged = changed && !explicitPaths;
   const scopeLabel = paths
-    ? `, ${paths.length} ${changed && !explicitPaths ? 'changed' : 'explicit'} path(s)`
+    ? `, ${paths.length} ${fromChanged ? 'changed' : 'explicit'} path(s)`
     : ', walking assets/**';
   console.log(`${write ? '✍️  Writing' : '🔍 Dry-run'} — threshold ${thresholdKb} KB${scopeLabel}`);
   console.log('');

--- a/scripts/optimize-assets.js
+++ b/scripts/optimize-assets.js
@@ -5,6 +5,7 @@ import { readFile, readdir, rename, stat, unlink, writeFile } from 'node:fs/prom
 import { dirname, extname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import sharp from 'sharp';
+import { getChangedAssets } from './upload-assets.js';
 
 const JPEG_QUALITY = 80;
 const WEBP_QUALITY = 80;
@@ -77,6 +78,20 @@ export const resolvePaths = async ({ rootDir, paths }) => {
   }
 
   return { files, errors, warnings };
+};
+
+// Scope the optimizer to the branch's new/changed assets, reusing upload-assets'
+// git detection. getChangedAssets includes formats this optimizer cannot encode
+// (.svg, .gif), so re-filter to ALLOWED_EXTS. Returns a warning (and no paths)
+// outside a git repo — never falls back to walking all assets, which under --write
+// would re-encode already-committed files.
+export const resolveChangedPaths = (rootDir) => {
+  const changed = getChangedAssets(rootDir);
+  if (changed === null) {
+    return { paths: [], warning: 'Not in a git repository — no changed assets to optimise.' };
+  }
+  const paths = changed.filter((p) => ALLOWED_EXTS.has(extname(p).toLowerCase()));
+  return { paths, warning: null };
 };
 
 const DIR_LIMITS = [
@@ -262,9 +277,10 @@ export const run = async ({ rootDir, write = false, paths, thresholdKb = DEFAULT
   return { results, warnings };
 };
 
-const parseArgs = (argv) => {
+export const parseArgs = (argv) => {
   const args = argv.slice(2);
   const write = args.includes('--write');
+  const changed = args.includes('--changed');
 
   const thresholdIdx = args.indexOf('--threshold-kb');
   let thresholdKb = DEFAULT_THRESHOLD_KB;
@@ -285,7 +301,7 @@ const parseArgs = (argv) => {
     paths = raw.split(',').map((p) => p.trim()).filter(Boolean);
   }
 
-  return { write, thresholdKb, paths };
+  return { write, changed, thresholdKb, paths };
 };
 
 const isMainModule = () => {
@@ -295,26 +311,43 @@ const isMainModule = () => {
 };
 
 if (isMainModule()) {
-  const { write, thresholdKb, paths } = parseArgs(process.argv);
+  const { write, changed, thresholdKb, paths: explicitPaths } = parseArgs(process.argv);
   const rootDir = join(dirname(fileURLToPath(import.meta.url)), '..');
 
-  console.log(
-    `${write ? '✍️  Writing' : '🔍 Dry-run'} — threshold ${thresholdKb} KB${paths ? `, ${paths.length} explicit path(s)` : ', walking assets/**'}`,
-  );
+  // --changed scopes to the branch's new/changed assets (publish flow). Explicit
+  // --paths wins if both are given; bare invocation still walks assets/**.
+  let paths = explicitPaths;
+  let changedWarning;
+  if (changed && !explicitPaths) {
+    const resolved = resolveChangedPaths(rootDir);
+    paths = resolved.paths;
+    changedWarning = resolved.warning;
+  }
+
+  const scopeLabel = paths
+    ? `, ${paths.length} ${changed && !explicitPaths ? 'changed' : 'explicit'} path(s)`
+    : ', walking assets/**';
+  console.log(`${write ? '✍️  Writing' : '🔍 Dry-run'} — threshold ${thresholdKb} KB${scopeLabel}`);
   console.log('');
 
   try {
-    const { results, warnings } = await run({ rootDir, write, paths, thresholdKb });
+    if (changedWarning) console.warn(`⚠️  ${changedWarning}`);
 
-    for (const w of warnings) {
-      console.warn(`⚠️  ${w}`);
-    }
+    if (paths && paths.length === 0) {
+      console.log('No changed assets to optimise.');
+    } else {
+      const { results, warnings } = await run({ rootDir, write, paths, thresholdKb });
 
-    console.log(formatReport(results));
+      for (const w of warnings) {
+        console.warn(`⚠️  ${w}`);
+      }
 
-    if (!write) {
-      console.log('');
-      console.log('Run with --write to overwrite originals in place.');
+      console.log(formatReport(results));
+
+      if (!write) {
+        console.log('');
+        console.log('Run with --write to overwrite originals in place.');
+      }
     }
   } catch (err) {
     console.error('❌ Optimisation failed:', err.message ?? err);


### PR DESCRIPTION
Closes #66

## What

Wires the already-existing image optimizer (`scripts/optimize-assets.js`) into the publish flow so oversized images are compressed in place **before** they are committed and uploaded to Vercel Blob. Scope: **local skill only, no CI change** (as chosen in the issue).

## Changes

- **`feat(scripts)`** — add a `--changed` flag + `resolveChangedPaths()` to the optimizer. It reuses `getChangedAssets()` from `upload-assets.js`, re-filters to the optimizer's supported formats (`.jpg/.jpeg/.png/.webp` — drops `.svg/.gif`), and **never falls back to walking all assets** outside a git repo (avoids re-encoding committed files under `--write`). `parseArgs` is now exported.
- **`feat(scripts)`** — two pnpm scripts delegating to the existing module: `optimize-assets` (dry-run report) and `optimize-assets:write` (write variant), both scoped to the branch's changed assets via `--changed`.
- **`feat(publish-content)`** — the skill now runs `pnpm optimize-assets:write` **before** asset sync / validate / PR, and surfaces the before/after report.
- **`docs(readme)`** — corrected the false "Automatic asset optimization via Vercel Blob" claim to describe the actual publish-time, local behavior.

## Acceptance criteria

- [x] pnpm scripts expose the optimizer (dry-run + write), both delegating to the existing module
- [x] `publish-content` runs the write variant over the branch's changed assets before sync/validate/PR
- [x] Images ≤ threshold left unchanged; only oversized rewritten in place
- [x] Concise optimization report (files touched + bytes saved)
- [x] Default 400 KB threshold + encoding/quality unchanged
- [x] README claim corrected
- [x] No CI workflow changes

## Tests

New TDD coverage in `scripts/__tests__/optimize-assets.test.js` for `resolveChangedPaths` (changed-only selection, `.svg/.gif` exclusion, not-in-git no-mass-rewrite, success-case return shape) and `parseArgs --changed`. Full suite: 171 passing; `pnpm validate` clean.