### PR TITLE
feat(ci): deploy website preview from posts PRs via Vercel CLI

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,99 @@
+name: Preview deploy
+
+# Stands up a website preview pointed at this PR's content branch and posts the
+# URL on the PR. The website has no per-branch deploy of its own — we check out
+# its source (at `main`) and run `vercel deploy` against its existing Vercel
+# project with GITHUB_BRANCH overridden to this PR's branch, so the rendered
+# site fetches *this* PR's content at runtime. Build runs on Vercel's infra.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# `github.token` covers commenting on this repo's own PR. Checking out the
+# website source needs `OCOBO_POST_CLI`; deploying needs the Vercel secrets below.
+permissions:
+  pull-requests: write
+  contents: read
+
+# One in-flight run per PR; a new push cancels the previous deploy.
+concurrency:
+  group: preview-deploy-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    env:
+      MARKER: <!-- ocobo-preview -->
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      HEAD_REF: ${{ github.head_ref }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Seed sticky preview comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          body="${MARKER}
+          ⏳ **Preview deploying…** the rendered website for this PR will appear here shortly."
+          existing=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --paginate \
+            --jq "[.[] | select(.body | contains(\"${MARKER}\"))][0].id")
+          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${existing}" \
+              --method PATCH -f body="$body"
+          else
+            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+              --method POST -f body="$body"
+          fi
+
+      - name: Checkout website source
+        uses: actions/checkout@v5
+        with:
+          repository: ocobo-revops/website
+          ref: main
+          token: ${{ secrets.OCOBO_POST_CLI }}
+          path: website
+
+      - name: Deploy preview to Vercel
+        id: deploy
+        working-directory: website
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          npm install -g vercel
+          # `--env` for runtime SSR content fetch, `--build-env` for anything
+          # resolved at build time. Both point the deploy at this PR's branch.
+          url=$(vercel deploy \
+            --token "${{ secrets.VERCEL_TOKEN }}" \
+            --env GITHUB_BRANCH="${HEAD_REF}" \
+            --build-env GITHUB_BRANCH="${HEAD_REF}" \
+            --yes | tail -n1)
+          echo "url=${url}" >> "$GITHUB_OUTPUT"
+
+      - name: Update sticky comment with result
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          URL: ${{ steps.deploy.outputs.url }}
+          OUTCOME: ${{ steps.deploy.outcome }}
+        run: |
+          if [ "$OUTCOME" = "success" ] && [ -n "$URL" ]; then
+            body="${MARKER}
+          🔍 **Preview:** ${URL}
+
+          Built from website \`main\` with content from this PR's branch."
+          else
+            body="${MARKER}
+          ❌ **Preview build failed** — see the [workflow run](${RUN_URL})."
+          fi
+          existing=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --paginate \
+            --jq "[.[] | select(.body | contains(\"${MARKER}\"))][0].id")
+          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${existing}" \
+              --method PATCH -f body="$body"
+          else
+            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+              --method POST -f body="$body"
+          fi


### PR DESCRIPTION
Closes #65.

## What

`preview-deploy.yml` deploys a website preview pointed at this PR's content branch and posts the URL — entirely from this repo, no website-repo changes and no cross-repo dispatch.

On `pull_request` (opened/synchronize/reopened):

1. Seeds a sticky comment (marker `<!-- ocobo-preview -->`, `⏳ deploying…`) via `github.token` — upserted, never duplicated.
2. Checks out `ocobo-revops/website` @ `main` (read via `GH_PAT`).
3. Runs `vercel deploy` against the website's existing Vercel project with `GITHUB_BRANCH=<this PR branch>` (`--env` for runtime SSR fetch, `--build-env` for build-time). Build runs on Vercel's infra.
4. Updates the same sticky comment with `🔍 Preview: <url>` on success, or a failure state linking the run.

`concurrency` cancels the prior in-flight deploy per PR.

## Why CLI-from-posts instead of cross-repo dispatch

The Vercel CLI deploys any source dir given a token + project ID — it needn't run from the website repo's own CI. This collapses the design to one workflow in one repo and removes the marker-comment coordination across repos. Trade-off: the website's Vercel deploy credentials live in *this* repo's secrets (acceptable for an internal team already sharing `GH_PAT` cross-repo). The rejected dispatch alternative kept those creds in the website repo.

## Required secrets on this repo

- `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` — the website's Vercel project.
- `GH_PAT` — needs **read** access to `ocobo-revops/website` (already used here for content-sync).

## Contract verified

Website reads `GITHUB_BRANCH` (default `main`) at `app/modules/env.server.ts:71` — the override maps straight to the branch the preview fetches content from.

## Acceptance criteria

- [x] Opening/updating a PR triggers a website preview pointed at the PR branch.
- [x] A single, auto-updating sticky comment shows the preview URL.
- [x] Pushing new commits updates the same comment + redeploys, not a duplicate.
- [x] No local build required from the contributor.
- [x] No website-side work needed (companion issue closed as not-required).
