### PR TITLE
fix(ci): use OCOBO_POST_CLI for content-sync commit-back

### DIFF
--- a/.github/workflows/content-sync.yml
+++ b/.github/workflows/content-sync.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Commit back rewritten URLs
         id: commit_back
         env:
-          GH_PAT: ${{ secrets.GH_PAT }}
+          GH_PAT: ${{ secrets.OCOBO_POST_CLI }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
The `GH_PAT` secret is not available to this repo (it's neither a repo-level secret nor granted to `posts` at the org level). The content-sync commit-back step would therefore fail with an empty token the moment a PR changes assets — it just hasn't fired yet because no merged PR touched assets.

Point it at the repo-level `OCOBO_POST_CLI` secret, matching the new preview-deploy workflow (#69). Surfaced while debugging the same empty-token failure on the preview deploy.

No behaviour change unless assets change in a PR; this prevents a latent failure.