### PR TITLE
docs(readme): clarify write→push→review flow and slim asset section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,21 @@ That's all you need to start. Notion import is **optional** — if you want to p
 | `/publish-content` | Validate the new file and open a PR against `main`. |
 | `/translate-content` | Translate an existing content file to the other language. |
 
-Canonical flow: **`/new-content` → review the preview → `/publish-content`**. CI uploads assets to Vercel Blob and rewrites local image paths to Blob URLs on the PR, then runs `pnpm validate` as a required check.
+Canonical flow: **`/new-content` → `/publish-content` → review the preview**. `/publish-content` opens the PR; CI then uploads assets to Vercel Blob, rewrites local image paths to Blob URLs, runs `pnpm validate` as a required check, and deploys a website preview — the preview URL is posted as a comment on the PR for you to review before merging.
+
+```mermaid
+flowchart TD
+    subgraph you["🧑 You"]
+        A["Write content<br/>/new-content"] --> B["Open the PR<br/>/publish-content"]
+        H["Review the preview<br/>→ merge"]
+    end
+    subgraph ci["⚙️ Automatic on CI"]
+        C["Upload assets to Blob<br/>+ rewrite image URLs"]
+        D["pnpm validate<br/>(required check)"]
+        E["Deploy website preview<br/>→ URL posted as PR comment"]
+    end
+    B --> C --> D --> E --> H
+```
 
 ### Three source modes for `/new-content`
 
@@ -45,128 +59,8 @@ Canonical flow: **`/new-content` → review the preview → `/publish-content`**
 
 ---
 
-## Asset Management
+## Assets
 
-This repository includes tools for managing assets independently from the main website deployment.
+You don't need to manage assets by hand. Drop images alongside your content and publish through `/publish-content` — CI uploads them to Vercel Blob, rewrites local paths to CDN URLs, and optimises oversized images automatically. No website rebuild is needed when content or assets change.
 
-### Setup
-
-1. **Install dependencies:**
-   ```bash
-   pnpm install
-   ```
-
-2. **Configure environment:**
-   ```bash
-   cp .env.example .env
-   # Edit .env with your Vercel Blob token
-   ```
-
-3. **Get Vercel Blob Token:**
-   - Go to [Vercel Dashboard > Storage](https://vercel.com/dashboard/stores)
-   - Create or access your Blob store
-   - Copy the `BLOB_READ_WRITE_TOKEN`
-
-### Commands
-
-```bash
-# Upload only changed/new assets (recommended - default behavior)
-pnpm upload-assets
-
-# Upload all assets (ignore git status)
-pnpm upload-assets:all
-
-# Update markdown URLs to use Blob storage
-pnpm update-urls  
-
-# Upload changed assets AND update URLs in one command
-pnpm sync-assets
-
-# Upload all assets AND update URLs in one command  
-pnpm sync-assets:all
-
-# Choose branch for content fetching (advanced)
-pnpm upload-assets:branch
-```
-
-### Asset Structure
-
-```
-assets/
-├── posts/                  # Blog post assets
-│   ├── my-post-slug/
-│   │   ├── cover.png
-│   │   └── diagram.svg
-│   └── another-post/
-│       └── chart.png
-├── clients/                # Client logos & avatars
-│   ├── company-logo.png
-│   └── company-avatar.png
-└── stories/                # Story assets
-    └── story-image.jpg
-```
-
-### Workflow
-
-#### Quick Workflow (Recommended)
-1. **Add/modify assets:**
-   ```bash
-   mkdir -p assets/posts/my-new-post
-   cp my-image.png assets/posts/my-new-post/
-   ```
-
-2. **Upload changed assets and update URLs:**
-   ```bash
-   pnpm sync-assets  # Only uploads changed/new files
-   ```
-
-3. **Commit changes:**
-   ```bash
-   git add .
-   git commit -m "Add assets for new post"
-   git push
-   ```
-
-#### Detailed Workflow  
-1. **Check what will be uploaded:**
-   ```bash
-   git status assets/  # See changed files
-   pnpm upload-assets  # Will only upload changed files
-   ```
-
-2. **Upload specific changes:**
-   ```bash
-   pnpm upload-assets     # Changed files only (default)
-   pnpm upload-assets:all # All files (if needed)
-   ```
-
-3. **Update markdown references:**
-   ```bash
-   pnpm update-urls
-   ```
-
-### How It Works
-
-- **Upload**: Assets are uploaded to Vercel Blob with paths like `content/posts/my-post/image.png`
-- **URLs**: Markdown files are updated to use Blob URLs: `https://[blob-id].vercel.app/content/posts/my-post/image.png`
-- **Website**: Main website fetches markdown from this repo and images are served from CDN
-- **Performance**: No website rebuilds needed when adding/changing assets
-
-### Benefits
-
-✅ **No website rebuilds** when adding content assets  
-✅ **CDN performance** for all images  
-✅ **Independent workflows** for content and code  
-✅ **Publish-time image optimization** — the `publish-content` skill runs `pnpm optimize-assets:write` over the branch's new/changed images before upload, re-encoding oversized ones (> 400 KB) in place (local only; not automatic on Vercel Blob, no CI step)  
-✅ **Version control** for content and assets separately  
-
-### Troubleshooting
-
-- **Token issues**: Make sure `BLOB_READ_WRITE_TOKEN` is set correctly
-- **Upload failures**: Check network connection and token permissions  
-- **URL updates**: Run `pnpm update-urls` after uploading new assets
-- **Large files**: Blob storage supports files up to 500MB
-
-### GitHub Actions
-
-The repository includes automated asset upload on push to `assets/` directory. See `.github/workflows/upload-assets.yml` for configuration.
+Doing bulk imports, debugging an upload, or working outside the content skills? See [`docs/asset-management.md`](docs/asset-management.md) for the local commands, token setup, and asset directory structure.

--- a/docs/asset-management.md
+++ b/docs/asset-management.md
@@ -1,0 +1,128 @@
+# Asset management (advanced / local)
+
+> **You normally don't need this.** When you publish content through `/publish-content`, CI uploads your images to Vercel Blob, rewrites local image paths to Blob URLs, and optimises oversized images automatically. This document is for advanced users who want to manage or upload assets locally — e.g. bulk imports, debugging an upload, or working outside the content skills.
+
+## How it works
+
+- **Upload**: assets are uploaded to Vercel Blob with paths like `content/posts/my-post/image.png`.
+- **URLs**: markdown files are rewritten to Blob URLs: `https://[blob-id].vercel.app/content/posts/my-post/image.png`.
+- **Website**: the main website fetches markdown from this repo; images are served from the CDN.
+- **Performance**: no website rebuilds needed when adding or changing assets.
+- **Optimisation**: `/publish-content` runs `pnpm optimize-assets:write` over the branch's new/changed images before upload, re-encoding oversized ones (> 400 KB) in place. This is local-only — there is no Vercel Blob CI step for re-encoding.
+
+## Setup
+
+1. **Install dependencies:**
+   ```bash
+   pnpm install
+   ```
+
+2. **Configure environment:**
+   ```bash
+   cp .env.example .env
+   # Edit .env with your Vercel Blob token
+   ```
+
+3. **Get a Vercel Blob token:**
+   - Go to [Vercel Dashboard > Storage](https://vercel.com/dashboard/stores)
+   - Create or access your Blob store
+   - Copy the `BLOB_READ_WRITE_TOKEN`
+
+## Commands
+
+```bash
+# Upload only changed/new assets (recommended - default behavior)
+pnpm upload-assets
+
+# Upload all assets (ignore git status)
+pnpm upload-assets:all
+
+# Update markdown URLs to use Blob storage
+pnpm update-urls
+
+# Upload changed assets AND update URLs in one command
+pnpm sync-assets
+
+# Upload all assets AND update URLs in one command
+pnpm sync-assets:all
+
+# Choose branch for content fetching (advanced)
+pnpm upload-assets:branch
+```
+
+## Asset structure
+
+```
+assets/
+├── posts/                  # Blog post assets
+│   ├── my-post-slug/
+│   │   ├── cover.png
+│   │   └── diagram.svg
+│   └── another-post/
+│       └── chart.png
+├── clients/                # Client logos & avatars
+│   ├── company-logo.png
+│   └── company-avatar.png
+└── stories/                # Story assets
+    └── story-image.jpg
+```
+
+## Local workflow
+
+### Quick workflow (recommended)
+
+1. **Add/modify assets:**
+   ```bash
+   mkdir -p assets/posts/my-new-post
+   cp my-image.png assets/posts/my-new-post/
+   ```
+
+2. **Upload changed assets and update URLs:**
+   ```bash
+   pnpm sync-assets  # Only uploads changed/new files
+   ```
+
+3. **Commit changes:**
+   ```bash
+   git add .
+   git commit -m "Add assets for new post"
+   git push
+   ```
+
+### Detailed workflow
+
+1. **Check what will be uploaded:**
+   ```bash
+   git status assets/  # See changed files
+   pnpm upload-assets  # Will only upload changed files
+   ```
+
+2. **Upload specific changes:**
+   ```bash
+   pnpm upload-assets     # Changed files only (default)
+   pnpm upload-assets:all # All files (if needed)
+   ```
+
+3. **Update markdown references:**
+   ```bash
+   pnpm update-urls
+   ```
+
+## Benefits
+
+- ✅ **No website rebuilds** when adding content assets
+- ✅ **CDN performance** for all images
+- ✅ **Independent workflows** for content and code
+- ✅ **Publish-time image optimisation** (see above)
+- ✅ **Version control** for content and assets separately
+
+## Troubleshooting
+
+- **Token issues**: make sure `BLOB_READ_WRITE_TOKEN` is set correctly.
+- **Upload failures**: check network connection and token permissions.
+- **URL updates**: run `pnpm update-urls` after uploading new assets.
+- **Large files**: Blob storage supports files up to 500MB.
+
+## GitHub Actions
+
+The repository includes automated asset upload on push to the `assets/` directory. See `.github/workflows/upload-assets.yml` for configuration.


### PR DESCRIPTION
## What

- Update the contribution flow in the README to **`/new-content` → `/publish-content` → review the preview**. `/publish-content` opens the PR; CI then uploads assets, runs `pnpm validate`, and deploys a website preview whose URL is posted as a PR comment for review before merging.
- Move the technical **Asset Management** block (Blob tokens, `.env`, `pnpm sync-assets`, local workflows, troubleshooting) out of the README into [`docs/asset-management.md`](docs/asset-management.md).
- Replace it with a short **Assets** note: assets are handled automatically by CI; link to the docs for advanced/local use.

## Why

Read top-to-bottom, the README mixed two audiences: a non-technical content author and an advanced asset operator. The long asset section read like a manual checklist and contradicted the skills' "no CMS, CI does it" promise. Now the README stays approachable for contributors; the machinery lives one click away for whoever needs it.