### PR TITLE
fix(team): add missing displayOrder, remove spurious slug field

### DIFF
--- a/team/edmond-de-maistre.md
+++ b/team/edmond-de-maistre.md
@@ -1,7 +1,7 @@
 ---
-slug: edmond-de-maistre
 name: Edmond de Maistre
 track: builder
+displayOrder: 15
 avatar: https://ipjmp3k0z0p479cb.public.blob.vercel-storage.com/content/team/edmond-de-maistre.png
 role:
   fr: Revenue Operations Associate

--- a/team/hugo-moulon.md
+++ b/team/hugo-moulon.md
@@ -1,7 +1,7 @@
 ---
-slug: hugo-moulon
 name: Hugo Moulon
 track: builder
+displayOrder: 16
 avatar: https://ipjmp3k0z0p479cb.public.blob.vercel-storage.com/content/team/hugo-moulon.jpeg
 role:
   fr: RevOps Manager

--- a/team/jeanne-hebben.md
+++ b/team/jeanne-hebben.md
@@ -1,7 +1,7 @@
 ---
-slug: jeanne-hebben
 name: Jeanne Hebben
 track: builder
+displayOrder: 14
 avatar: https://ipjmp3k0z0p479cb.public.blob.vercel-storage.com/content/team/jeanne-hebben.png
 role:
   fr: Senior Revenue Operations Manager

--- a/team/thomas-sionville.md
+++ b/team/thomas-sionville.md
@@ -1,7 +1,7 @@
 ---
-slug: thomas-sionville
 name: Thomas Sionville
 track: builder
+displayOrder: 13
 avatar: https://ipjmp3k0z0p479cb.public.blob.vercel-storage.com/content/team/thomas-sionville.png
 role:
   fr: RevOps Manager


### PR DESCRIPTION
## Problem

PR #73 added 4 new team members without the required `displayOrder` field, and with a spurious `slug:` key in the frontmatter. This caused the team page to crash (undefined sort key), making all team photos disappear.

## Fix

- Added `displayOrder: 13–16` to thomas-sionville, jeanne-hebben, edmond-de-maistre, hugo-moulon
- Removed the `slug:` field (derived from filename, not frontmatter)

## Urgency

Production crash — team photos are not visible on the site.