### PR TITLE
content(team): translate bio.en for 4 members + auto-translate in skill

### DIFF
--- a/.claude/skills/new-content/SKILL.md
+++ b/.claude/skills/new-content/SKILL.md
@@ -166,14 +166,16 @@ No body for tools.
 3. **track** — existing values: `architect | builder | expert-engineer`. Ask to pick or type a new one.
 4. **avatar** (required) — drag image path here. Copy to `assets/team/` and record for sync.
 5. **role.fr** — French job title.
-6. **role.en** — English job title.
+6. **role.en** — English job title. **Auto-translate, never duplicate:** if the source supplied only the French value (or the extracted `role.en` is identical to `role.fr`), translate it to English yourself and show the result to confirm — do not copy the French through.
 7. **bio.fr** — French one-sentence bio.
-8. **bio.en** — English one-sentence bio.
+8. **bio.en** — English one-sentence bio. Same rule as role.en: if only French is available (or the value equals `bio.fr`), translate from `bio.fr` and present it for confirmation — never copy the French verbatim. (PR #73 shipped four members with the French bio duplicated into `bio.en` exactly this way.)
 9. **linkedin (optional)** — full LinkedIn URL.
 10. **displayOrder** — integer for ordering on the team page. Suggest `maxDisplayOrder + 1` (computed in Step 2) as the default; accept Enter to use it. **Mandatory gate — never skip, regardless of source.** This field is required by the website schema and is never supplied by the Notion/local adapters, so it stays "missing" after prefill — ask it explicitly even when every other field came from a source. If the contributor has no preference, write the suggested value. Before Step 4, assert the assembled frontmatter contains a positive integer `displayOrder`; if not, stop and resolve it.
 11. **active (optional, default `true`)** — `true | false`.
 12. **featuredOnAboutUs (optional, default `false`)** — `true | false`.
 13. **color (optional)** — `yellow | coral | sky`.
+
+**Bilingual gate — before Step 4:** assert that `role.en` ≠ `role.fr` and `bio.en` ≠ `bio.fr`. An `en` value identical to its `fr` counterpart means the source had no English and it was copied through untranslated — translate it before continuing. Identical values are only acceptable for genuinely language-neutral strings (e.g. a role title that is the same in both languages, like "RevOps Manager"); when in doubt, confirm with the contributor.
 
 No body for team members.
 

--- a/team/edmond-de-maistre.md
+++ b/team/edmond-de-maistre.md
@@ -8,7 +8,7 @@ role:
   en: Revenue Operations Associate
 bio:
   fr: Spécialiste de la performance commerciale et du pilotage par la donnée fiable.
-  en: Spécialiste de la performance commerciale et du pilotage par la donnée fiable.
+  en: Specialist in commercial performance and reliable, data-driven decision-making.
 linkedin: "https://www.linkedin.com/in/edmond-de-maistre/"
 active: true
 featuredOnAboutUs: false

--- a/team/hugo-moulon.md
+++ b/team/hugo-moulon.md
@@ -8,7 +8,7 @@ role:
   en: RevOps Manager
 bio:
   fr: Expert dans la structuration et l'optimisation des processus Sales et CSM, de la compréhension métier à l'adaptation du CRM jusqu'au pilotage par la donnée, pour accélérer la croissance et éliminer les frictions opérationnelles.
-  en: Expert dans la structuration et l'optimisation des processus Sales et CSM, de la compréhension métier à l'adaptation du CRM jusqu'au pilotage par la donnée, pour accélérer la croissance et éliminer les frictions opérationnelles.
+  en: Expert in structuring and optimising Sales and CSM processes — from grasping the business needs to tailoring the CRM and steering by data — to accelerate growth and remove operational friction.
 linkedin: "https://www.linkedin.com/in/hugo-moulon-44b4a613b/"
 active: true
 featuredOnAboutUs: false

--- a/team/jeanne-hebben.md
+++ b/team/jeanne-hebben.md
@@ -8,7 +8,7 @@ role:
   en: Senior Revenue Operations Manager
 bio:
   fr: Experte dans l'optimisation et l'automatisation des process Sales pour aligner stratégie commerciale et performance opérationnelle.
-  en: Experte dans l'optimisation et l'automatisation des process Sales pour aligner stratégie commerciale et performance opérationnelle.
+  en: Expert in optimising and automating Sales processes to align commercial strategy with operational performance.
 linkedin: "https://www.linkedin.com/in/jeanne-hebben/"
 active: true
 featuredOnAboutUs: false

--- a/team/thomas-sionville.md
+++ b/team/thomas-sionville.md
@@ -8,7 +8,7 @@ role:
   en: RevOps Manager
 bio:
   fr: Spécialiste de l'automatisation des processus et de la structuration des données Sales et CSM.
-  en: Spécialiste de l'automatisation des processus et de la structuration des données Sales et CSM.
+  en: Specialist in process automation and in structuring Sales and CSM data.
 linkedin: "https://www.linkedin.com/in/thomas-revops/"
 active: true
 featuredOnAboutUs: false


### PR DESCRIPTION
## Pourquoi

La PR #73 a livré edmond, hugo, jeanne et thomas avec `bio.en` recopié **mot pour mot** du `bio.fr` (donc en français). Cette PR corrige le contenu **et** la cause dans la skill.

## 1 — Contenu : `bio.en` traduits

| Membre | bio.en |
|--------|--------|
| edmond | Specialist in commercial performance and reliable, data-driven decision-making. |
| hugo | Expert in structuring and optimising Sales and CSM processes — from grasping the business needs to tailoring the CRM and steering by data — to accelerate growth and remove operational friction. |
| jeanne | Expert in optimising and automating Sales processes to align commercial strategy with operational performance. |
| thomas | Specialist in process automation and in structuring Sales and CSM data. |

`bio.fr` inchangé, `role.en` déjà en anglais.

## 2 — Prévention : `fix(new-content)`

Cause racine : quand la source (Notion) n'a pas de valeur anglaise, la skill recopiait le français. Désormais :
- `role.en` / `bio.en` sont **auto-traduits** depuis le `fr` quand l'anglais est absent ou identique au français (confirmation présentée au contributeur).
- **Garde-fou avant Step 4** : assertion `en ≠ fr`, avec exception pour les titres réellement neutres (ex. "RevOps Manager"). Même logique que le gate `displayOrder` de #76.

## Checks
- `pnpm validate` ✅

Indépendante des autres PR (#76 mergée, #77 en CI).