### PR TITLE
fix(job): fold founding-sales extra sections under rendered anchors

### DIFF
--- a/jobs/fr/founding-sales-business-development-manager.md
+++ b/jobs/fr/founding-sales-business-development-manager.md
@@ -11,86 +11,105 @@ tallyFormId: 2EVoOb
 status: published
 publishedAt: 2026-06-22
 intro: >
-  Ocobo accompagne depuis trois ans les plus belles scale-ups et entreprises
-  françaises sur leurs enjeux Revenue & Operations. Nos associés fondateurs sont
-  encore très présents dans le cycle commercial et c'est précisément pour changer
-  cela que nous recrutons. Ce poste est celui du premier commercial senior interne
-  d'Ocobo : un profil expérimenté, capable de générer de la demande, de conduire un
-  cycle de vente complexe de bout en bout, d'apporter sa propre vision et son réseau,
-  et de vendre un projet de transformation.
+  La mission du Founding Sales | Business Development Manager est de prendre en
+  charge l'acquisition de nouveaux clients d'Ocobo de bout en bout : générer la
+  demande, conduire des cycles de vente complexes au niveau dirigeant et vendre des
+  projets de transformation Revenue. C'est le premier commercial senior interne
+  d'Ocobo, celui qui prend le relais des associés sur le cycle commercial.
+
+  L'objectif : une fonction commerciale qui tourne sans les fondateurs, un pipeline
+  prévisible et une pratique de vente documentée et transmissible.
 ---
 
 ### La Mission {% #mission %}
 
-Rattaché(e) directement au CEO, vous prenez en charge l'acquisition de nouveaux clients d'Ocobo avec une large autonomie.
+Rattaché(e) directement au CEO, tu prends en charge l'acquisition de nouveaux clients d'Ocobo avec une large autonomie. Tu construis ton pipeline, tu conduis les cycles de vente jusqu'à la signature et tu structures la pratique commerciale au fur et à mesure. Les associés restent disponibles sur les dossiers les plus stratégiques, mais tu es en première ligne.
 
-Ce poste est celui du **premier commercial senior interne d'Ocobo** : un profil expérimenté, capable de générer de la demande, de conduire un cycle de vente complexe de bout en bout, d'apporter sa propre vision et son réseau, et de vendre un projet de transformation.
+Tu interviens auprès de CEO, CRO et COO de scale-ups B2B en forte croissance, sur des cycles de vente longs et consultatifs. Ce que tu construis a vocation à durer et à être transmis à la future équipe GTM.
+
+#### À propos d'Ocobo
+
+Première agence de conseil 100% spécialisée en Revenue Strategy & Operations en France. Fondée en 2023 par trois associés issus de TheFork, Yousign et Spendesk, nous accompagnons les scale-ups B2B dans la structuration de leur machine revenue, de l'acquisition au renouvellement. Parmi nos clients : Qonto, Welcome to the Jungle, Qare, Berger-Levrault, Skello, CybelAngel. Notre méthode propriétaire, The Revenue Experience System™, couvre quatre piliers : Alignement, Technologie, Performance et Enablement.
 
 ### Responsabilités {% #responsabilites %}
 
-#### Développer et piloter le pipeline
+#### 1. Générer la demande et piloter le pipeline
 
-- Vous construisez votre pipeline, qualifiez les opportunités et conduisez les négociations jusqu'à la signature sur les deals standards.
-- Les associés restent disponibles sur les dossiers les plus stratégiques, mais vous êtes en première ligne.
+- Construire ton pipeline, qualifier les opportunités et conduire les négociations jusqu'à la signature sur les deals standards.
+- Définir et animer les canaux d'acquisition : outbound, réseau, partenariats, événements. Identifier les leviers les plus pertinents, les tester et mesurer leur impact.
+- T'appuyer sur la marque Ocobo, reconnue dans l'écosystème scale-up B2B français, et contribuer à la renforcer.
+- Adresser le bon niveau : lire un contexte, poser les bonnes questions et positionner Ocobo comme un partenaire de transformation, pas comme un prestataire.
 
-#### Définir et animer les canaux d'acquisition
+{% callout title="Compétences clés" %}
+- Maîtrise du cycle de vente complexe B2B, de la génération de pipe au closing
+- Aisance C-suite, discours stratégique et posture de pair
+- Multi-canal acquisition : outbound, réseau, événements
+- Sens du contexte, qualification, capacité à challenger
+{% /callout %}
 
-- Outbound, réseau, partenariats, événements : vous identifiez les leviers les plus pertinents, les testez et mesurez leur impact.
-- Ocobo dispose d'une marque reconnue dans l'écosystème scale-up B2B français. Vous vous en appuyez et contribuez à la renforcer.
+#### 2. Activer l'écosystème partenaires
 
-#### Animer les partenariats stratégiques
+- Animer les partenariats stratégiques : HubSpot, Dust, Lemlist, Qobra, Modjo et une dizaine d'autres partenaires technologiques constituent un canal d'acquisition à fort potentiel, encore peu structuré.
+- En faire un levier réel de génération d'opportunités qualifiées.
+- Construire des relations durables avec les partenaires et identifier les schémas de co-vente qui fonctionnent.
 
-- HubSpot, Dust, Lemlist, Qobra, Modjo et une dizaine d'autres partenaires technologiques constituent un canal d'acquisition à fort potentiel, encore peu structuré.
-- Vous en faites un levier réel de génération d'opportunités qualifiées.
+{% callout title="Compétences clés" %}
+- Animation de partenariats et co-vente
+- Networking et développement de l'écosystème
+- Structuration d'un canal indirect
+{% /callout %}
 
-#### Structurer la pratique commerciale
+#### 3. Structurer la pratique commerciale
 
-- Vous documentez le process de vente, tenez le CRM avec rigueur et identifiez les patterns gagnants.
-- Ce que vous construisez a vocation à durer et à être transmis.
+- Documenter le process de vente, tenir le CRM avec rigueur et identifier les patterns gagnants.
+- Construire des fondations qui durent et qui pourront être transmises à la future équipe GTM.
+- Suivre les indicateurs utiles et faire progresser la méthode dans le temps.
 
-#### Adresser le bon niveau
-
-- Nos interlocuteurs sont des CEO, CRO et COO de scale-ups en forte croissance.
-- Vous savez lire un contexte, poser les bonnes questions et positionner Ocobo comme un partenaire de transformation, pas comme un prestataire.
+{% callout title="Compétences clés" %}
+- Culture data et process, pipelines bien tenus
+- Formalisation et documentation du playbook
+- Rigueur CRM, indicateurs actionnables
+{% /callout %}
 
 ### Profil recherché {% #profil %}
 
 - **5 à 7 ans d'expérience** en développement commercial B2B dans des environnements exigeants : conseil, agence premium ou SaaS B2B avec des cycles de vente longs
-- **À l'aise au niveau C-suite** : vous portez un discours stratégique et savez adapter votre posture à des interlocuteurs dirigeants
+- **À l'aise au niveau C-suite** : tu portes un discours stratégique et sais adapter ta posture à des interlocuteurs dirigeants
 - **Autonome sur l'intégralité du cycle** : génération de pipe, qualification, proposition, négociation, closing, passation à l'équipe delivery
 - Une **culture data et process** solide : pipelines bien tenus, indicateurs utiles, méthodes qui tiennent dans la durée
 - Un **réseau actif** dans l'écosystème scale-up et VC français, ou une capacité démontrée à en construire un rapidement, est un vrai plus
-- La connaissance ou l'intérêt du monde **RevOps et GTM** est un atout non négligeable, mais pas un prérequis : vous serez accompagné(e) sur le fond métier
+- La connaissance ou l'intérêt du monde **RevOps et GTM** est un atout, mais pas un prérequis : tu seras accompagné(e) sur le fond métier
+- Français courant, anglais professionnel apprécié
 
-### Ce que nous proposons
+#### Ce que nous proposons
 
 {% callout title="Un rôle à construire" %}
-Vous n'intégrez pas une fonction commerciale existante, vous la fondez. Les premières bases sont posées : première version du playbook commercial formalisé, outils en place. Vous prenez le relais avec la légitimité et l'autonomie pour aller plus loin.
+Tu n'intègres pas une fonction commerciale existante, tu la fondes. Les premières bases sont posées : première version du playbook commercial formalisé, outils en place. Tu prends le relais avec la légitimité et l'autonomie pour aller plus loin.
 {% /callout %}
 
 {% callout title="Un terrain qualifié" %}
-Qonto, Welcome to the Jungle, Qare, Berger-Levrault, Skello, CybelAngel : les références sont là, le réseau est actif, la marque est reconnue dans l'écosystème. Vous accélérez quelque chose qui fonctionne déjà.
+Qonto, Welcome to the Jungle, Qare, Berger-Levrault, Skello, CybelAngel : les références sont là, le réseau est actif, la marque est reconnue dans l'écosystème. Tu accélères quelque chose qui fonctionne déjà.
 {% /callout %}
 
 {% callout title="Une vitrine du RevOps en 2026" %}
-Chez Ocobo, vous travaillez avec les meilleures méthodologies et technologies du marché et vous les pratiquez au quotidien, pas seulement en les vendant. L'intelligence artificielle est pleinement intégrée à notre façon d'opérer : prospection, qualification, analyse, performance commerciale. Vous serez à la fois utilisateur et ambassadeur de ces approches auprès de vos interlocuteurs.
+Chez Ocobo, tu travailles avec les meilleures méthodologies et technologies du marché et tu les pratiques au quotidien, pas seulement en les vendant. L'intelligence artificielle est pleinement intégrée à notre façon d'opérer : prospection, qualification, analyse, performance commerciale. Tu seras à la fois utilisateur et ambassadeur de ces approches auprès de tes interlocuteurs.
 {% /callout %}
 
 {% callout title="Co-construire l'agence de demain" %}
-Ce poste n'est pas un rôle d'exécution. Vous participez activement à définir ce que devient Ocobo, son positionnement, ses offres, ses standards. Une équipe entièrement senior, une méthode propriétaire, des clients engagés et l'ambition collective de devenir le partenaire RevOps de référence pour les scale-ups B2B françaises.
+Ce poste n'est pas un rôle d'exécution. Tu participes activement à définir ce que devient Ocobo, son positionnement, ses offres, ses standards. Une équipe entièrement senior, une méthode propriétaire, des clients engagés et l'ambition collective de devenir le partenaire RevOps de référence pour les scale-ups B2B françaises.
 {% /callout %}
 
 {% callout title="Un package sérieux" %}
-Fixe compétitif et variable indexé sur vos résultats. Le plan de rémunération est construit ensemble, en transparence.
+Fixe compétitif et variable indexé sur tes résultats. Le plan de rémunération est construit ensemble, en transparence.
 {% /callout %}
 
-### Perspectives d'évolution
+#### Perspectives d'évolution
 
-Si les résultats sont au rendez-vous, l'ambition est de structurer progressivement une fonction GTM autour de ce poste, avec un rôle de leadership à la clé. Rien n'est préétabli : l'évolution se construira en fonction de vos résultats et de la croissance d'Ocobo.
+Si les résultats sont au rendez-vous, l'ambition est de structurer progressivement une fonction GTM autour de ce poste, avec un rôle de leadership à la clé. Rien n'est préétabli : l'évolution se construira en fonction de tes résultats et de la croissance d'Ocobo.
 
-### Processus de recrutement
+#### Processus de recrutement
 
-1. Échange de 30 minutes avec Benjamin Boileux (CEO) — contexte et fit mutuel
+1. Échange de 30 minutes avec Benjamin Boileux (CEO) : contexte et fit mutuel
 2. Étude de cas : qualification et présentation d'une opportunité fictive
 3. Rencontre avec l'équipe fondatrice
 4. Proposition


### PR DESCRIPTION
## Problem

On ocobo.co the founding-sales job page only rendered **La Mission / Responsabilités / Profil recherché**. The site renders just those three anchored sections (`#mission`, `#responsabilites`, `#profil`); any top-level `###` section after `### Profil recherché` is dropped — so *Ce que nous proposons*, *Perspectives d'évolution* and *Processus de recrutement* were invisible.

## Fix

Folded the orphaned sections under the rendered anchors as `####` subheadings (matching the pattern in the other job files):

- **La Mission** ← *Ce que nous proposons* (5 callouts) + *Perspectives d'évolution*
- **Profil recherché** ← *Processus de recrutement*

No content lost; only three `###` anchors remain.

## Files changed

- `jobs/fr/founding-sales-business-development-manager.md`

## Review checklist

- [ ] All copy still present, now under a rendered anchor
- [ ] `pnpm validate` passes