### PR TITLE
Add Revenue Operations Engineer job posting

### DIFF
--- a/jobs/fr/revenue-operations-engineer.md
+++ b/jobs/fr/revenue-operations-engineer.md
@@ -1,0 +1,99 @@
+---
+title: Revenue Operations Engineer
+icon: "🧑‍🔬"
+contractType: CDI
+seniority: 3-5 ans
+location: Paris (On site)
+hiringContact: aude-cadiot
+applyEmail: recrutement@ocobo.co
+tallyFormId: 44VaVB
+status: published
+publishedAt: 2026-08-24
+intro: >
+  La mission du Revenue Operations Engineer est de construire, déployer et maintenir
+  les systèmes qui font tourner les équipes Revenue de nos clients : CRM, automatisations,
+  intégrations entre outils, qualité de la donnée, et aujourd'hui agents IA. Il est le
+  binôme technique des Revenue Operations Managers, celui qui transforme les décisions
+  d'architecture en solutions qui tiennent dans la durée.
+---
+
+### La Mission {% #mission %}
+
+La différence en 2026 : une part croissante de ce que tu déploies embarque de l'IA. Enrichissement, qualification, préparation de RDV, synthèse d'interactions, mise à jour automatique du CRM, aide à la décision commerciale. Ton job n'est pas de tester des outils IA, c'est de les mettre en production avec le même niveau d'exigence que le reste : fiable, mesuré, documenté, maintenable.
+
+Au sein d'une Revenue Squad expérimentée, tu interviens en tant que référent technique sur les missions clients. Tu travailles en binôme avec les RevOps Managers sur les sujets d'architecture et de déploiement, et tu es garant de la qualité technique des solutions mises en place.
+
+Tu auras l'occasion de travailler sur plusieurs clients (2 à 3 en parallèle) avec des stacks et des enjeux variés, ce qui garantit une montée en compétences rapide et une exposition large aux outils du marché.
+
+### Responsabilités {% #responsabilites %}
+
+#### 1. Construction et déploiement de solutions techniques
+
+- Configurer, optimiser et déployer des instances CRM (HubSpot en priorité, Salesforce en parallèle) : objets, propriétés, pipelines, workflows d'automatisation.
+- Concevoir et implémenter des architectures d'automatisation via N8N, Make ou équivalent, avec une vraie rigueur sur la gestion des erreurs, les boucles et la maintenabilité.
+- Connecter les outils entre eux via API (REST, webhooks), ETL ou connecteurs natifs.
+- Gérer les migrations de données : nettoyage, transformation, import/export entre systèmes.
+- Assurer la qualité et la cohérence de la donnée dans le temps (déduplication, enrichissement, gouvernance).
+- Définir les standards techniques de déploiement pour des mises en production robustes.
+
+{% callout title="Compétences clés" %}
+- Maîtrise HubSpot (Admin, Ops Hub) et/ou Salesforce
+- Pratique confirmée de N8N, Make ou équivalent
+- Lecture et utilisation d'APIs (REST, JSON, webhooks)
+- Rigueur sur les migrations et la gouvernance de données
+- Capacité à produire des systèmes qui durent, pas juste pour la démo
+{% /callout %}
+
+#### 2. IA appliquée au Revenue
+
+- Concevoir et déployer des agents IA dans les process Revenue de nos clients : qualification et scoring, enrichissement, préparation de RDV, synthèse d'interactions, mise à jour de CRM, next best action.
+- Intégrer des LLM dans les chaînes d'automatisation (API Anthropic, OpenAI, ou via N8N) : conception des prompts, structuration des sorties, chaînage d'appels, gestion des cas d'échec.
+- Poser les garde-fous qui rendent l'IA déployable en production : validation humaine sur les actions sensibles, fallback, traçabilité, coût par exécution, confidentialité des données clients.
+- Mesurer la fiabilité réelle des cas d'usage déployés (taux d'erreur, adoption, temps gagné) et itérer, plutôt que livrer un POC et passer à la suite.
+- Préparer la donnée client pour l'IA : sans donnée propre et structurée, aucun agent ne tient.
+- Industrialiser des briques IA réutilisables d'une mission à l'autre et contribuer à l'offre Ocobo sur le sujet.
+
+{% callout title="Compétences clés" %}
+- Cas d'usage IA déjà déployés en production, pas seulement testés
+- Prompting structuré, sorties contraintes (JSON), chaînage d'appels
+- Compréhension des limites : non-déterminisme, hallucination, coût, latence
+- Sensibilité aux enjeux de confidentialité et RGPD sur les données clients
+- Appétence pour les protocoles d'orchestration (MCP, agents) et capacité à distinguer ce qui est mature de ce qui est du bruit
+{% /callout %}
+
+#### 3. Stack & standards techniques
+
+- Être le référent technique sur l'ensemble de la stack RevOps des clients : sales engagement, marketing automation, customer success, facturation, productivité commerciale.
+- Évaluer et recommander les bons outils selon le rapport valeur/complexité, IA comprise, en distinguant la promesse produit de ce que l'outil fait réellement.
+- Définir les standards techniques de déploiement Ocobo et contribuer à la construction de la stack interne.
+
+{% callout title="Compétences clés" %}
+- Connaissance de l'écosystème RevOps (Apollo, Salesloft, Planhat, Chargebee, Modjo…)
+- Esprit de benchmarking, capacité à arbitrer entre solutions
+- Sens du rapport valeur/complexité
+{% /callout %}
+
+#### 4. Documentation & transmission
+
+- Documenter les architectures déployées : schémas de flux, guides d'administration, référentiels techniques.
+- Produire des livrables de fin de mission clairs et actionnables pour les équipes clients.
+- Former les consultants RevOps Ocobo aux outils et aux cas d'usage IA déployés, pour qu'ils sachent les vendre et les opérer.
+- Contribuer à la capitalisation des bonnes pratiques techniques en interne.
+
+{% callout title="Compétences clés" %}
+- Rigueur documentaire, clarté rédactionnelle
+- Pédagogie, capacité à vulgariser le technique
+- Sens du livrable, orientation client
+{% /callout %}
+
+### Profil recherché {% #profil %}
+
+- Bac+4/5 (ingénieur, université, école de commerce avec forte composante technique)
+- 3 à 5 ans d'expérience sur des sujets techniques RevOps, intégration de systèmes, ou déploiement d'outils SaaS
+- Maîtrise d'un CRM (SFDC ou HubSpot en priorité) : configuration avancée, workflows, APIs
+- Pratique confirmée de l'automatisation via N8N, Make ou équivalent
+- Expérience avec les APIs REST : lecture de documentation, appels, gestion de webhooks
+- Expérience concrète de mise en production de cas d'usage IA (agents, LLM intégrés à des workflows, automatisations augmentées), avec le recul sur ce qui a marché et ce qui a cassé
+- Compréhension suffisante du métier Revenue pour concevoir des solutions qui répondent au vrai problème
+- Exposition à des interlocuteurs métier (contexte client, agence ou interne exigeant)
+- Autonomie, rigueur, sens des priorités

--- a/jobs/fr/revenue-operations-engineer.md
+++ b/jobs/fr/revenue-operations-engineer.md
@@ -4,6 +4,7 @@ icon: "🧑‍🔬"
 contractType: CDI
 seniority: 3-5 ans
 location: Paris (On site)
+startDate: 2026-09-01
 hiringContact: aude-cadiot
 applyEmail: recrutement@ocobo.co
 tallyFormId: 44VaVB
@@ -20,6 +21,8 @@ intro: >
 ### La Mission {% #mission %}
 
 La différence en 2026 : une part croissante de ce que tu déploies embarque de l'IA. Enrichissement, qualification, préparation de RDV, synthèse d'interactions, mise à jour automatique du CRM, aide à la décision commerciale. Ton job n'est pas de tester des outils IA, c'est de les mettre en production avec le même niveau d'exigence que le reste : fiable, mesuré, documenté, maintenable.
+
+Tu es le binôme technique des Revenue Operations Managers, celui qui transforme les décisions d'architecture en solutions qui tiennent dans la durée. Pas des démos qui s'effondrent en production.
 
 Au sein d'une Revenue Squad expérimentée, tu interviens en tant que référent technique sur les missions clients. Tu travailles en binôme avec les RevOps Managers sur les sujets d'architecture et de déploiement, et tu es garant de la qualité technique des solutions mises en place.
 


### PR DESCRIPTION
Sourced from the Notion draft, reformatted to match the mission/responsabilites/profil structure required by the site's Markdoc renderer, with hiring contact Aude Cadiot and the Tally form for application (44VaVB).